### PR TITLE
Adding kpt annotations for network and subnetwork

### DIFF
--- a/asm/cluster/cluster.yaml
+++ b/asm/cluster/cluster.yaml
@@ -33,7 +33,7 @@ spec:
     mesh_id: "proj-PROJECT_NUMBER" # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.project.projectNumber","value":"PROJECT_NUMBER"}]}}
   loggingService: logging.googleapis.com/kubernetes
   monitoringService: monitoring.googleapis.com/kubernetes
-  network: default
-  subnetwork: default
+  network: default  # {"type":"string","x-kustomize":{"setter":{"name":"gcloud.compute.network"}}}
+  subnetwork: default # {"type":"string","x-kustomize":{"setter":{"name":"gcloud.compute.subnetwork"}}}
   releaseChannel:
     channel: REGULAR


### PR DESCRIPTION
A user may not be using the default VPC network or subnetwork.  Allowing `kpt` to change these values would be convenient.