### PR TITLE
Updating ASM Managed Control Plane branch to support anthoscli beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,15 @@ kpt pkg get https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages.
 
 # To set tunables, use `kpt cfg set`. To see all tunables, run `kpt cfg list-setters <folder>`
 kpt cfg set asm gcloud.compute.location ${LOCATION}
-kpt cfg set asm gcloud.compute.cluster ${CLUSTER_NAME}
+kpt cfg set asm gcloud.container.cluster ${CLUSTER_NAME}
 kpt cfg set asm gcloud.core.project ${PROJECT_ID}
 
-kpt cfg set cluster location ${LOCATION}
-kpt cfg set cluster cluster-name ${CLUSTER_NAME}
+kpt cfg set cluster gcloud.compute.location ${LOCATION}
+kpt cfg set cluster gcloud.container.cluster ${CLUSTER_NAME}
 kpt cfg set cluster gcloud.core.project ${PROJECT_ID}
 
+kpt cfg set project gcloud.compute.location ${LOCATION}
+kpt cfg set project gcloud.container.cluster ${CLUSTER_NAME}
 kpt cfg set project gcloud.core.project ${PROJECT_ID}
 
 # Optional: commit state to git

--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -26,6 +26,11 @@ openAPI:
         setter:
           name: anthos.servicemesh.sink-auth-mode
           value: GOOGLE
+    io.k8s.cli.setters.anthos.servicemesh.jwks-transformer-interval:
+      x-k8s-cli:
+        setter:
+          name: anthos.servicemesh.jwks-transformer-interval
+          value: 20m
     io.k8s.cli.setters.gcloud.core.project:
       x-k8s-cli:
         setter:
@@ -108,17 +113,17 @@ openAPI:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.images.galley
-          value: 'gcr.io/asm-testing/galley:release-1.5-asm-10'
+          value: 'gcr.io/gke-release/asm/galley:1.5.4-asm.2'
     io.k8s.cli.setters.anthos.servicemesh.images.istiod:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.images.istiod
-          value: 'gcr.io/asm-testing/pilot:release-1.5-asm-10'
+          value: 'gcr.io/gke-release/asm/pilot:1.5.4-asm.2'
     io.k8s.cli.setters.anthos.servicemesh.images.proxy:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.images.proxy
-          value: 'gcr.io/asm-testing/proxyv2:release-1.5-asm-10'
+          value: 'gcr.io/gke-release/asm/proxyv2:1.5.4-asm.2'
     io.k8s.cli.setters.anthos.servicemesh.debug.trace-id:
       x-k8s-cli:
         setter:
@@ -145,6 +150,8 @@ openAPI:
           name: project-id
           pattern: asm-galley-service-account@PROJECT_ID.iam.gserviceaccount.com
           values:
+          - marker: CONTAINER_ENDPOINT
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.api_endpoint_overrides.container'
           - marker: PROJECT_ID
             ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
     io.k8s.cli.substitutions.k8s-neg-service-account:
@@ -154,4 +161,16 @@ openAPI:
           pattern: neg-service-account@PROJECT_ID.iam.gserviceaccount.com
           values:
           - marker: PROJECT_ID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
+    io.k8s.cli.substitutions.gkeio-cluster:
+      x-k8s-cli:
+        substitution:
+          name: gkeio-cluster
+          pattern: gke://PROJECTID/LOCATION/CLUSTERNAME
+          values:
+          - marker: CLUSTERNAME
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.container.cluster'
+          - marker: LOCATION
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.compute.location'
+          - marker: PROJECTID
             ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'

--- a/asm/cluster-td/neg-controller-default-backend.yaml
+++ b/asm/cluster-td/neg-controller-default-backend.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   name: l7-default-backend
   namespace: kube-system
   labels:
@@ -43,6 +45,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   # This must match the --default-backend-service argument of the l7 lb
   # controller and is required because GCE mandates a default backend.
   name: default-http-backend

--- a/asm/cluster-td/neg-controller-rbac.yaml
+++ b/asm/cluster-td/neg-controller-rbac.yaml
@@ -5,12 +5,15 @@ metadata:
   name: neg-controller
   namespace: kube-system
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     iam.gke.io/gcp-service-account: "neg-service-account@[PROJECT_ID].iam.gserviceaccount.com" # {"$ref":"#/definitions/io.k8s.cli.substitutions.k8s-neg-service-account"}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: system:controller:neg-controller
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -59,6 +62,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:controller:neg-controller
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/asm/cluster-td/neg-controller.yaml
+++ b/asm/cluster-td/neg-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   name: l7-lb-controller
   namespace: kube-system
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
     k8s-app: gcp-lb-controller

--- a/asm/infrastructure_configs.sh
+++ b/asm/infrastructure_configs.sh
@@ -147,9 +147,6 @@ fi
 if ! kubectl get ns istio-system > /dev/null; then
   kubectl create ns istio-system
 fi
-if ! kubectl -n istio-system get secret google-cloud-key > /dev/null 2>&1; then
-  kubectl -n istio-system create secret generic google-cloud-key  --from-file key.json=<(fetchCloudKey asm-galley-service-account)
-fi
 
 gcloud projects add-iam-policy-binding ${PROJECT_ID} \
     --member serviceAccount:service-$(gcloud projects list --filter="project_id=${PROJECT_ID}" --format='value(project_number)')@gcp-sa-meshdataplane.iam.gserviceaccount.com \

--- a/asm/trafficdirector/crd-all.gen.yaml
+++ b/asm/trafficdirector/crd-all.gen.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-citadel
@@ -728,6 +729,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-citadel
@@ -1453,6 +1455,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-mixer
@@ -1664,6 +1667,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-mixer
@@ -1757,6 +1761,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-mixer
@@ -1841,6 +1846,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-mixer
@@ -1921,6 +1927,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-pilot
@@ -2884,6 +2891,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-pilot
@@ -3180,6 +3188,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-pilot
@@ -3331,6 +3340,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-pilot
@@ -3479,6 +3489,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-pilot
@@ -3605,6 +3616,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-pilot
@@ -4280,6 +4292,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: mixer
@@ -4356,6 +4369,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: mixer
@@ -4520,6 +4534,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: mixer
@@ -4582,6 +4597,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: mixer
@@ -4737,6 +4753,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-pilot
@@ -4824,6 +4841,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: mixer
@@ -4912,6 +4930,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: mixer
@@ -5023,6 +5042,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: mixer
@@ -5225,6 +5245,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-pilot
@@ -5424,6 +5445,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-pilot
@@ -5500,6 +5522,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     "helm.sh/resource-policy": keep
   labels:
     app: istio-pilot

--- a/asm/trafficdirector/neg-controller-config.yaml
+++ b/asm/trafficdirector/neg-controller-config.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
-kind: Namespace
+kind: ConfigMap
 metadata:
   annotations:
     gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
-  name: istio-system
-  labels:
-    istio-operator-managed: Reconcile
-    istio-injection: disabled
----
+  name: ingress-controller-asm-cm-config
+  namespace: kube-system
+data:
+  enable-asm: "true"
+  asm-skip-namespaces: "kube-system,istio-system"

--- a/asm/trafficdirector/td-configmap-galley.yaml
+++ b/asm/trafficdirector/td-configmap-galley.yaml
@@ -1,20 +1,28 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   name: istio-galley-config-td
   namespace: istio-system
 data:
   TRAFFICDIRECTORADDRESS: "trafficdirector.googleapis.com:443" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.endpoint.trafficdirector-address"}
   MESHCAADDRESS: "meshca.googleapis.com:443" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.endpoint.meshca-address"}
+  CA_ADDR: "meshca.googleapis.com:443" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.endpoint.meshca-address"}
   SINKADDRESS: "meshconfig.googleapis.com:443" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.serivcemesh.meshconfig-address"}
-  SINKAUTHMODE: "GOOGLE" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.sink-auth-mode"}
+  SINKAUTHMODE: "GOOGLE-STS" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.sink-auth-mode"}
   SDSPATH: "unix:/etc/istio/proxy/SDS"
   PROJECT_ID: "[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
   GOOGLE_APPLICATION_CREDENTIALS: /var/secrets/google/key.json
   AUDIENCE: "[PROJECT_ID].svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
   trustDomain: "[PROJECT_ID].svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
   TRUST_DOMAIN: "[PROJECT_ID].svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
+  GCP_GKE_CLUSTER_URL: https://container.googleapis.com/v1/projects/[PROJECT_ID]/locations/us-central1-c/clusters/asm-free-trial # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-cluster-url"}
+  GKE_CLUSTER_URL: https://container.googleapis.com/v1/projects/[PROJECT_ID]/locations/us-central1-c/clusters/asm-free-trial # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-cluster-url"}
   gkeClusterUrl: https://container.googleapis.com/v1/projects/[PROJECT_ID]/locations/us-central1-c/clusters/asm-free-trial # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-cluster-url"}
   GCP_METADATA: "[PROJECT_ID]|[PROJECT_NUMBER]|asm-free-trial|us-central1-c" # { "$ref": "#/definitions/io.k8s.cli.substitutions.gcp-metadata" }
+  GCP_PROJECT_NUMBER: "[PROJECT_NUMBER]" # { "$ref": "#/definitions/io.k8s.cli.substitutions.gcp-project-number" }
   ISTIO_META_MESH_ID: "proj-[PROJECT_NUMBER]" # { "$ref": "#/definitions/io.k8s.cli.substitutions.mesh-id" }
   ISTIO_META_TRAFFICDIRECTOR_GCP_PROJECT_NUMBER: "[PROJECT_NUMBER]" # { "$ref": "#/definitions/io.k8s.cli.substitutions.gcp-project-number" }
+  ENABLE_JWKS_TRANSFORMER: "true"
+  JWKS_TRANSFORMER_INTERVAL: "20m" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.jwks-transformer-interval"}

--- a/asm/trafficdirector/td-configmap-injection.yaml
+++ b/asm/trafficdirector/td-configmap-injection.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   name: istio-sidecar-injector-td
   namespace: istio-system
   labels:

--- a/asm/trafficdirector/td-configmap-mesh.yaml
+++ b/asm/trafficdirector/td-configmap-mesh.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   name: istio-mesh-td
   namespace: istio-system
   labels:

--- a/asm/trafficdirector/td-galley-rbac.yaml
+++ b/asm/trafficdirector/td-galley-rbac.yaml
@@ -6,12 +6,15 @@ metadata:
   name: asm-galley-service-account
   namespace: istio-system
   annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
     iam.gke.io/gcp-service-account: "asm-galley-service-account@[PROJECT_ID].iam.gserviceaccount.com" # {"$ref":"#/definitions/io.k8s.cli.substitutions.k8s-galley-service-account"}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: asm-galley-binding
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   labels:
     app: asm-galley
     release: asm-galley
@@ -29,6 +32,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: asm-galley
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   labels:
     release: asm-galley
 rules:

--- a/asm/trafficdirector/td-galley.yaml
+++ b/asm/trafficdirector/td-galley.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: asm-galley-push
   namespace: istio-system
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   labels:
     app: asm-galley-push
     release: asm-galley-push
@@ -25,9 +27,11 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: asm-galley-service-account
+      securityContext:
+        fsGroup: 1337
       containers:
       - name: galley
-        image: gcr.io/asm-testing/galley:release-1.5-asm-10 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.images.galley"}
+        image: gcr.io/gke-release/asm/galley:1.5.4-asm.2 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.images.galley"}
         imagePullPolicy: "Always"
         ports:
         - containerPort: 9443
@@ -60,9 +64,6 @@ spec:
         - --sinkMeta=project_id=$(PROJECT_ID),sds_path=$(SDSPATH),trace=0,enable_security_beta=false # {"$ref":"#/definitions/io.k8s.cli.substitutions.sink-meta"}
         - --excludedResourceKinds=Pod,Node,Endpoints
         - --enableServiceDiscovery
-        env:
-        - name: ENABLE_JWKS_TRANSFORMER
-          value: "true"
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -70,12 +71,17 @@ spec:
         - name: mesh-config
           mountPath: /etc/mesh-config
           readOnly: true
-        - mountPath: /var/secrets/google
-          name: google-cloud-key
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
       volumes:
-      - name: google-cloud-key
-        secret:
-          secretName: google-cloud-key
+      - name: istio-token
+        projected:
+          defaultMode: 77
+          sources:
+          - serviceAccountToken:
+              audience: "[PROJECT_ID].svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
+              expirationSeconds: 43200
+              path: istio-token
       - name: config
         # Should be created at cluster creation time, include info about the cluster and vendor-specific options.
         configMap:

--- a/asm/trafficdirector/td-gateway.yaml
+++ b/asm/trafficdirector/td-gateway.yaml
@@ -1,0 +1,331 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
+  labels:
+    app: asm-td-ingressgateway
+    istio: ingressgateway
+    release: istio
+  name: asm-td-ingressgateway
+  namespace: istio-system
+spec:
+  maxReplicas: 5
+  metrics:
+    - resource:
+        name: cpu
+        targetAverageUtilization: 80
+      type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: asm-td-ingressgateway
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
+  labels:
+    app: asm-td-ingressgateway
+    istio: ingressgateway
+  name: asm-td-ingressgateway
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      app: asm-td-ingressgateway
+      istio: ingressgateway
+  strategy:
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 25%
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: asm-td-ingressgateway
+        chart: gateways
+        heritage: Tiller
+        istio: ingressgateway
+        release: istio
+        service.istio.io/canonical-name: asm-td-ingressgateway
+        service.istio.io/canonical-revision: "1.5"
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+              weight: 2
+            - preference:
+                matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - ppc64le
+              weight: 2
+            - preference:
+                matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - s390x
+              weight: 2
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - ppc64le
+                      - s390x
+      containers:
+        - args:
+            - proxy
+            - router
+            - --domain
+            - $(POD_NAMESPACE).svc.cluster.local
+            - --drainDuration
+            - 45s
+            - --parentShutdownDuration
+            - 1m0s
+            - --discoveryAddress
+            - trafficdirector.googleapis.com:443
+            - --stsPort=15463
+            - --proxyLogLevel=trace
+            - --proxyComponentLogLevel=misc:error
+            - --log_output_level=default:info
+            - --connectTimeout
+            - 10s
+            - --proxyAdminPort
+            - "15000"
+            - --dnsRefreshRate
+            - 300s
+            - --controlPlaneAuthPolicy
+            - NONE
+            - --trust-domain=$(TRUST_DOMAIN)
+            - --serviceCluster
+            - asm-td-ingressgateway
+          envFrom:
+          - configMapRef:
+              name: istio-galley-config-td
+              optional: false
+          env:
+          - name: JWT_POLICY
+            value: third-party-jwt
+          - name: PILOT_CERT_PROVIDER
+            value: kubernetes
+          - name: ISTIO_BOOTSTRAP
+            value: /var/lib/istio/envoy/gcp_envoy_bootstrap_tmpl.json
+          - name: ISTIO_META_TRAFFICDIRECTOR_ENABLE_ISTIO_STACKDRIVER_TELEMETRY
+            value: "true"
+          - name: ISTIO_META_TRAFFICDIRECTOR_ACCESS_LOG_PATH
+            value: /dev/stdout
+          - name: ISTIO_META_TRAFFICDIRECTOR_WORKLOAD_NAME
+            value: csm-auth-default
+          - name: CA_PROVIDER
+            value: GoogleCA
+          - name: PLUGINS
+            value: GoogleTokenExchange
+          - name: ISTIO_KUBE_APP_PROBERS
+            value: '{}'
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: INSTANCE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+          - name: ISTIO_META_WORKLOAD_NAME
+            value: asm-td-ingressgateway
+          - name: ISTIO_META_OWNER
+            value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/asm-td-ingressgateway
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: ISTIO_META_istio
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['istio']
+          - name: ISTIO_META_CONFIG_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: ISTIO_META_CLUSTER_ID
+            value: Kubernetes
+          image: gcr.io/ymzhu-istio/proxyv2:ymzhu-asm-1.5 ## TODO: Fixme
+          imagePullPolicy: IfNotPresent
+          name: istio-proxy
+          volumeMounts:
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
+              readOnly: true
+            - mountPath: /var/run/ingress_gateway
+              name: ingressgatewaysdsudspath
+            - mountPath: /etc/istio/pod
+              name: podinfo
+            - mountPath: /etc/istio/ingressgateway-certs
+              name: ingressgateway-certs
+              readOnly: true
+            - mountPath: /etc/istio/ingressgateway-ca-certs
+              name: ingressgateway-ca-certs
+              readOnly: true
+      serviceAccountName: asm-td-ingressgateway-service-account
+      volumes:
+        - downwardAPI:
+            items:
+              - fieldRef:
+                  fieldPath: metadata.labels
+                path: labels
+              - fieldRef:
+                  fieldPath: metadata.annotations
+                path: annotations
+          name: podinfo
+        - emptyDir: {}
+          name: ingressgatewaysdsudspath
+        - name: istio-token
+          projected:
+            defaultMode: 420
+            sources:
+              - serviceAccountToken:
+                  audience: "[PROJECT_ID].svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
+                  expirationSeconds: 43200
+                  path: istio-token
+        - name: ingressgateway-certs
+          secret:
+            optional: true
+            secretName: asm-td-ingressgateway-certs
+        - name: ingressgateway-ca-certs
+          secret:
+            optional: true
+            secretName: asm-td-ingressgateway-ca-certs
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
+  name: ingressgateway
+  namespace: istio-system
+  labels:
+    app: asm-td-ingressgateway
+    istio: ingressgateway
+
+    release: istio
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: asm-td-ingressgateway
+      istio: ingressgateway
+
+      release: istio
+---
+
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
+  name: asm-td-ingressgateway-sds
+  namespace: istio-system
+  labels:
+    release: istio
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
+---
+
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
+  name: asm-td-ingressgateway-sds
+  namespace: istio-system
+  labels:
+    release: istio
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: asm-td-ingressgateway-sds
+subjects:
+  - kind: ServiceAccount
+    name: asm-td-ingressgateway-service-account
+---
+
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
+  labels:
+    app: asm-td-ingressgateway
+    istio: ingressgateway
+    release: istio
+  name: asm-td-ingressgateway
+  namespace: istio-system
+spec:
+  ports:
+    - name: http2
+      port: 80
+      targetPort: 80
+  selector:
+    app: asm-td-ingressgateway
+    istio: ingressgateway
+  type: LoadBalancer
+
+---
+
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
+  name: asm-td-ingressgateway-service-account
+  namespace: istio-system
+  labels:
+    app: asm-td-ingressgateway
+    istio: ingressgateway
+
+    release: istio
+---

--- a/asm/trafficdirector/td-istiod-asm-rbac.yaml
+++ b/asm/trafficdirector/td-istiod-asm-rbac.yaml
@@ -3,6 +3,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   name: asm-td-service-account
   namespace: istio-system
   labels:
@@ -14,6 +16,8 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   name: asm-td-istio-system
   labels:
     app: istiod
@@ -94,6 +98,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   name: asm-td-istio-system
   labels:
     app: pilot

--- a/asm/trafficdirector/td-istiod-asm.yaml
+++ b/asm/trafficdirector/td-istiod-asm.yaml
@@ -3,6 +3,8 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: asm-td
   namespace: istio-system
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   labels:
     release: asm-td
 spec:
@@ -23,6 +25,8 @@ kind: PodDisruptionBudget
 metadata:
   name: asm-td
   namespace: istio-system
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   labels:
     release: asm-td
 spec:
@@ -37,6 +41,8 @@ kind: Service
 metadata:
   name: asm-td
   namespace: istio-system
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   labels:
     release: asm-td
 spec:
@@ -62,6 +68,8 @@ kind: Deployment
 metadata:
   name: asm-td
   namespace: istio-system
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   labels:
     app: asm-td
     release: asm-td
@@ -84,7 +92,7 @@ spec:
       serviceAccountName: asm-td-service-account
       containers:
       - name: discovery
-        image: gcr.io/asm-testing/pilot:release-1.5-asm-10 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.images.istiod"}
+        image: gcr.io/gke-release/asm/pilot:1.5.4-asm.2 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.images.istiod"}
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
@@ -130,7 +138,7 @@ spec:
         - name: PILOT_EXTERNAL_GALLEY
           value: "false"
         - name: PROXY_IMAGE
-          value: gcr.io/asm-testing/proxyv2:release-1.5-asm-10 # { "$ref": "#/definitions/io.k8s.cli.setters.anthos.servicemesh.images.proxy" }
+          value: gcr.io/gke-release/asm/proxyv2:1.5.4-asm.2 # { "$ref": "#/definitions/io.k8s.cli.setters.anthos.servicemesh.images.proxy" }
         resources:
           requests:
             cpu: 101m

--- a/asm/trafficdirector/td-mutatingwebhook.yaml
+++ b/asm/trafficdirector/td-mutatingwebhook.yaml
@@ -1,6 +1,8 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
   name: asm-td
 webhooks:
   # name, service.name, and istio-env should be identical for consistency.

--- a/cluster/Kptfile
+++ b/cluster/Kptfile
@@ -53,6 +53,30 @@ openAPI:
             ref: '#/definitions/io.k8s.cli.setters.gcloud.compute.location'
           - marker: PROJECTID
             ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
+    io.k8s.cli.substitutions.gkeio-cluster:
+      x-k8s-cli:
+        substitution:
+          name: gkeio-cluster
+          pattern: gke://PROJECTID/LOCATION/CLUSTERNAME
+          values:
+          - marker: CLUSTERNAME
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.container.cluster'
+          - marker: LOCATION
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.compute.location'
+          - marker: PROJECTID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
+    io.k8s.cli.substitutions.bootstrap-cluster:
+      x-k8s-cli:
+        substitution:
+          name: bootstrap-cluster
+          pattern: bootstrap://PROJECTID/LOCATION/CLUSTERNAME
+          values:
+          - marker: CLUSTERNAME
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.container.cluster'
+          - marker: LOCATION
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.compute.location'
+          - marker: PROJECTID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
     io.k8s.cli.substitutions.mesh-id:
       x-k8s-cli:
         substitution:
@@ -61,3 +85,11 @@ openAPI:
           values:
           - marker: PROJECT_NUMBER
             ref: '#/definitions/io.k8s.cli.setters.gcloud.project.projectNumber'
+    io.k8s.cli.substitutions.trust-domain:
+      x-k8s-cli:
+        substitution:
+          name: trust-domain
+          pattern: PROJECT_ID.svc.id.goog
+          values:
+          - marker: PROJECT_ID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'

--- a/cluster/cluster/cluster.yaml
+++ b/cluster/cluster/cluster.yaml
@@ -1,26 +1,21 @@
-apiVersion: identity.cnrm.cloud.google.com/v1alpha2
-kind: IdentityNamespace
-metadata:
-  name: default
-  namespace: "[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
-spec: {}
 ---
-apiVersion: container.cnrm.cloud.google.com/v1alpha2
+apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerCluster
 metadata:
-  clusterName: "[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.full-cluster-name"}
+  annotations:
+    gke.io/cluster: "bootstrap://"
   name: asm-free-trial # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.container.cluster"}
   namespace: "[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
 spec:
   location: us-central1-c # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.compute.location"}
-  workloadIdentity:
-    identityNamespace: default
+  workloadIdentityConfig:
+    identityNamespace: "[PROJECT_ID].svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
   labels:
     mesh_id: "proj-[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.substitutions.mesh-id"}
   loggingService: logging.googleapis.com/kubernetes
   monitoringService: monitoring.googleapis.com/kubernetes
-  ipAllocationPolicy:
-    useIpAliases: true
+  # ipAllocationPolicy:
+  #   useIpAliases: true
   addonsConfig:
     horizontalPodAutoscaling:
       disabled: false
@@ -28,20 +23,19 @@ spec:
       disabled: true
     cloudrunConfig:
       disabled: true # {"$ref":"#/definitions/io.k8s.cli.setters.cloudrun-config-disabled"}
-  masterAuth:
-    username: admin
   network: default
   networkPolicy:
     enabled: true
-  minMasterVersion: "1.15.11-gke.1"
+  minMasterVersion: "1.15.11-gke.13"
   nodeConfig:
     metadata:
       disable-legacy-endpoints: "true"
 ---
-apiVersion: container.cnrm.cloud.google.com/v1alpha2
+apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerNodePool
 metadata:
-  clusterName: "[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.full-cluster-name"}
+  annotations:
+    gke.io/cluster: "bootstrap://"
   name: default-pool
   namespace: "[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
 spec:

--- a/project/Kptfile
+++ b/project/Kptfile
@@ -27,8 +27,31 @@ openAPI:
           values:
           - marker: PROJECT_ID
             ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
+
     io.k8s.cli.setters.gcloud.project.projectNumber:
       x-k8s-cli:
         setter:
           name: gcloud.project.projectNumber
           value: "[PROJECT_NUMBER]"
+    io.k8s.cli.substitutions.gkeio-cluster:
+      x-k8s-cli:
+        substitution:
+          name: gkeio-cluster
+          pattern: gke://PROJECTID/LOCATION/CLUSTERNAME
+          values:
+          - marker: CLUSTERNAME
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.container.cluster'
+          - marker: LOCATION
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.compute.location'
+          - marker: PROJECTID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
+    io.k8s.cli.setters.gcloud.container.cluster:
+      x-k8s-cli:
+        setter:
+          name: gcloud.container.cluster
+          value: asm-free-trial
+    io.k8s.cli.setters.gcloud.compute.location:
+      x-k8s-cli:
+        setter:
+          name: gcloud.compute.location
+          value: us-central1-c

--- a/project/project/enable-services.yaml
+++ b/project/project/enable-services.yaml
@@ -3,6 +3,7 @@ apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   annotations:
+    gke.io/cluster: "bootstrap://"
     cnrm.cloud.google.com/deletion-policy: "abandon"
     cnrm.cloud.google.com/disable-dependent-services: "false"
   namespace: "[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
@@ -13,6 +14,7 @@ apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   annotations:
+    gke.io/cluster: "bootstrap://"
     cnrm.cloud.google.com/deletion-policy: "abandon"
     cnrm.cloud.google.com/disable-dependent-services: "false"
   namespace: "[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
@@ -23,6 +25,7 @@ apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   annotations:
+    gke.io/cluster: "bootstrap://"
     cnrm.cloud.google.com/deletion-policy: "abandon"
     cnrm.cloud.google.com/disable-dependent-services: "false"
   namespace: "[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
@@ -33,6 +36,7 @@ apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   annotations:
+    gke.io/cluster: "bootstrap://"
     cnrm.cloud.google.com/deletion-policy: "abandon"
     cnrm.cloud.google.com/disable-dependent-services: "false"
   namespace: "[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
@@ -43,6 +47,7 @@ apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   annotations:
+    gke.io/cluster: "bootstrap://"
     cnrm.cloud.google.com/deletion-policy: "abandon"
     cnrm.cloud.google.com/disable-dependent-services: "false"
   namespace: "[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
@@ -53,6 +58,7 @@ apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   annotations:
+    gke.io/cluster: "bootstrap://"
     cnrm.cloud.google.com/deletion-policy: "abandon"
     cnrm.cloud.google.com/disable-dependent-services: "false"
   namespace: "[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
@@ -63,6 +69,7 @@ apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   annotations:
+    gke.io/cluster: "bootstrap://"
     cnrm.cloud.google.com/deletion-policy: "abandon"
     cnrm.cloud.google.com/disable-dependent-services: "false"
   namespace: "[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
@@ -73,6 +80,7 @@ apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   annotations:
+    gke.io/cluster: "bootstrap://"
     cnrm.cloud.google.com/deletion-policy: "abandon"
     cnrm.cloud.google.com/disable-dependent-services: "false"
   namespace: "[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
@@ -83,6 +91,7 @@ apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
 kind: Service
 metadata:
   annotations:
+    gke.io/cluster: "bootstrap://"
     cnrm.cloud.google.com/deletion-policy: "abandon"
     cnrm.cloud.google.com/disable-dependent-services: "false"
   namespace: "[PROJECT_ID]" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}

--- a/project/project/force-p4sa-generation.yaml
+++ b/project/project/force-p4sa-generation.yaml
@@ -1,25 +1,32 @@
----
-# This is an empty 1.4 control plane, used to force creation of p4sa
-apiVersion: install.istio.io/v1alpha2
-kind: IstioControlPlane
+# This is an empty istio control plane, used to force creation of p4sa
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
 metadata:
-  namespace: istio-operator
-  name: example-istiocontrolplane
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
+  namespace: istio-system
+  name: force-p4sa
 spec:
   profile: minimal
-  trafficManagement:
-    enabled: false
-  policy:
-    enabled: false
-  telemetry:
-    enabled: false
-  security:
-    enabled: false
-  configManagement:
-    enabled: false
-  gateways:
-    enabled: false
-  autoInjection:
-    enabled: false
-  coreDNS:
-    enabled: false
+  components:
+    base:
+      enabled: false
+    pilot:
+      enabled: false
+    proxy:
+      enabled: false
+    sidecarInjector:
+      enabled: false
+    policy:
+      enabled: false
+    telemetry:
+      enabled: false
+    citadel:
+      enabled: false
+    nodeAgent:
+      enabled: false
+    galley:
+      enabled: false
+    cni:
+      enabled: false
+

--- a/project/project/neg-sa.yaml
+++ b/project/project/neg-sa.yaml
@@ -4,6 +4,8 @@ kind: IAMServiceAccount
 metadata:
   name: neg-service-account
   namespace: "[PROJECT_ID]"  # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
 spec:
   displayName: Service Account for NEG controller
   projectRoles:

--- a/project/project/td-galley-sa.yaml
+++ b/project/project/td-galley-sa.yaml
@@ -4,22 +4,26 @@ kind: IAMServiceAccount
 metadata:
   name: asm-galley-service-account
   namespace: "[PROJECT_ID]"  # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
 spec:
   displayName: Istio galley credentials
   projectRoles:
   - roles/meshconfig.writer
-#---
-#apiVersion: iam.cnrm.cloud.google.com/v1alpha1
-#kind: IAMPolicy
-#metadata:
-#  name: asm-galley-iam-policy
-#  namespace: "[PROJECT_ID]"
-#spec:
-#  resourceRef:
-#    apiVersion: iam.cnrm.cloud.google.com/v1alpha1
-#    kind: IAMServiceAccount
-#    name: asm-galley-service-account
-#  bindings:
-#  - role: roles/iam.workloadIdentityUser
-#    members:
-#    - serviceAccount:[PROJECT_ID].svc.id.goog[istio-system/asm-galley-service-account] # {"$ref":"#/definitions/io.k8s.cli.substitutions.galley-service-account"}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1alpha1
+kind: IAMPolicy
+metadata:
+  name: asm-galley-iam-policy
+  namespace: "[PROJECT_ID]"  # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.core.project"}
+  annotations:
+    gke.io/cluster: "gke://[PROJECT_ID]/us-central1-c/asm-free-trial" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gkeio-cluster"}
+spec:
+ resourceRef:
+   apiVersion: iam.cnrm.cloud.google.com/v1alpha1
+   kind: IAMServiceAccount
+   name: asm-galley-service-account
+ bindings:
+ - role: roles/iam.workloadIdentityUser
+   members:
+   - serviceAccount:[PROJECT_ID].svc.id.goog[istio-system/asm-push-service-account] # {"$ref":"#/definitions/io.k8s.cli.substitutions.galley-service-account"}


### PR DESCRIPTION
Updating ASM Managed Control Plane branch to support AnthosCLI beta.

Also changed the Galley config to no longer require a serviceaccount key, and added an ASM gateway deployment. 