### PR TITLE
Rev asm version to 1.5.6-asm.0

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -61,7 +61,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.tag
-          value: 1.5.5-asm.2
+          value: 1.5.6-asm.0
     io.k8s.cli.substitutions.mesh-id:
       type: string
       x-k8s-cli:

--- a/asm/cluster/istio-operator.yaml
+++ b/asm/cluster/istio-operator.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   profile: asm
   hub: gcr.io/gke-release/asm # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.hub"}
-  tag: 1.5.5-asm.2 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.tag"}
+  tag: 1.5.6-asm.0 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.tag"}
   meshConfig:
     defaultConfig:
       proxyMetadata:


### PR DESCRIPTION
Instructions in docs reference 1.5.6-asm.0, but 1.5.5-asm.2 is pulled.

Instructions for upgrades in docs has users pulling `istio-1.5.6-asm.0-linux.tar.gz`, which `istioctl` conflicts with our packaged manifests.