### PR TITLE
Enable Stackdriver Tracing by default

### DIFF
--- a/asm-patch/resources/istio-operator.yaml
+++ b/asm-patch/resources/istio-operator.yaml
@@ -27,6 +27,17 @@ spec:
         GCP_METADATA: "PROJECT_ID|PROJECT_NUMBER|asm-cluster|us-central1-c" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-metadata"}
         TRUST_DOMAIN: "PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
         GKE_CLUSTER_URL: "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1-c/clusters/asm-cluster" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-cluster-url"}
+      tracing:
+        customTags:
+          service.istio.io/canonical-name:
+            environment:
+              name: CANONICAL_SERVICE
+              default_value: ""
+          service.istio.io/canonical-revision:
+            environment:
+              name: CANONICAL_REVISION
+              default_value: ""
+    enableTracing: true
   values:
     global:
       meshID: "proj-PROJECT_NUMBER" # {"$ref":"#/definitions/io.k8s.cli.substitutions.mesh-id"}
@@ -38,3 +49,5 @@ spec:
       multiCluster:
         # Provided to ensure a human readable name rather than a UUID.
         clusterName: "PROJECT_ID/us-central1-c/asm-cluster" # {"$ref":"#/definitions/io.k8s.cli.substitutions.cluster-name"}
+      proxy:
+        tracer: "stackdriver"

--- a/asm/cluster/istio-operator.yaml
+++ b/asm/cluster/istio-operator.yaml
@@ -26,6 +26,17 @@ spec:
         GCP_METADATA: "PROJECT_ID|PROJECT_NUMBER|asm-cluster|us-central1-c" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-metadata"}
         TRUST_DOMAIN: "PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
         GKE_CLUSTER_URL: "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1-c/clusters/asm-cluster" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-cluster-url"}
+      tracing:
+        customTags:
+          service.istio.io/canonical-name:
+            environment:
+              name: CANONICAL_SERVICE
+              default_value: ""
+          service.istio.io/canonical-revision:
+            environment:
+              name: CANONICAL_REVISION
+              default_value: ""
+    enableTracing: true
   values:
     global:
       meshID: "proj-PROJECT_NUMBER" # {"$ref":"#/definitions/io.k8s.cli.substitutions.mesh-id"}
@@ -37,3 +48,5 @@ spec:
       multiCluster:
         # Provided to ensure a human readable name rather than a UUID.
         clusterName: "PROJECT_ID/us-central1-c/asm-cluster" # {"$ref":"#/definitions/io.k8s.cli.substitutions.cluster-name"}
+      proxy:
+        tracer: "stackdriver"


### PR DESCRIPTION
Enable Stackdriver Tracing by default and add custom tags  for canonical service and revision