### PR TITLE
disable control plane monitoring in 1.6 for now

### DIFF
--- a/asm-citadel/cluster/istio-operator.yaml
+++ b/asm-citadel/cluster/istio-operator.yaml
@@ -26,8 +26,6 @@ spec:
         env:
         - name: SPIFFE_BUNDLE_ENDPOINTS
           value: ""
-        - name: ENABLE_STACKDRIVER_MONITORING
-          value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
         - name: TOKEN_AUDIENCES
           value: "istio-ca,PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.token-audiencesn"}
   meshConfig:

--- a/asm-patch-citadel/resources/istio-operator.yaml
+++ b/asm-patch-citadel/resources/istio-operator.yaml
@@ -27,8 +27,6 @@ spec:
         env:
         - name: SPIFFE_BUNDLE_ENDPOINTS
           value: ""
-        - name: ENABLE_STACKDRIVER_MONITORING
-          value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
         - name: TOKEN_AUDIENCES
           value: "istio-ca,PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.token-audiencesn"}
   meshConfig:

--- a/asm-patch/resources/istio-operator.yaml
+++ b/asm-patch/resources/istio-operator.yaml
@@ -27,8 +27,6 @@ spec:
         env:
         - name: SPIFFE_BUNDLE_ENDPOINTS
           value: "PROJECT_ID.svc.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints"}
-        - name: ENABLE_STACKDRIVER_MONITORING
-          value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
   meshConfig:
     defaultConfig:
       proxyMetadata:

--- a/asm/cluster/istio-operator.yaml
+++ b/asm/cluster/istio-operator.yaml
@@ -26,8 +26,6 @@ spec:
         env:
         - name: SPIFFE_BUNDLE_ENDPOINTS
           value: "PROJECT_ID.svc.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints"}
-        - name: ENABLE_STACKDRIVER_MONITORING
-          value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
   meshConfig:
     defaultConfig:
       proxyMetadata:


### PR DESCRIPTION
People started to use anthoscli to install ASM using this latest control plane monitoring enablement option and build that is not yet ready (<=1.6.8-asm.0). Will add this option back when the next patch version is ready.