### PR TITLE
update gke-release image url

### DIFF
--- a/asm-citadel/Kptfile
+++ b/asm-citadel/Kptfile
@@ -77,7 +77,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.canonicalServiceHub
-          value: gcr.io/gke-release/canonical-service-controller:1.6.8-asm.6          
+          value: gcr.io/gke-release/asm/canonical-service-controller:1.6.8-asm.9          
     io.k8s.cli.substitutions.mesh-id:
       type: string
       x-k8s-cli:

--- a/asm-citadel/canonical-service/controller.yaml
+++ b/asm-citadel/canonical-service/controller.yaml
@@ -318,7 +318,7 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: gcr.io/gke-release/canonical-service-controller:1.6.8-asm.6 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.canonicalServiceHub"}
+        image: gcr.io/gke-release/asm/canonical-service-controller:1.6.8-asm.9 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.canonicalServiceHub"}
         name: manager
         resources:
           limits:

--- a/asm-patch-citadel/Kptfile
+++ b/asm-patch-citadel/Kptfile
@@ -45,7 +45,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.canonicalServiceHub
-          value: gcr.io/gke-release/canonical-service-controller:1.6.8-asm.6          
+          value: gcr.io/gke-release/asm/canonical-service-controller:1.6.8-asm.9          
     io.k8s.cli.substitutions.mesh-id:
       type: string
       x-k8s-cli:

--- a/asm-patch-citadel/resources/canonical-service/controller.yaml
+++ b/asm-patch-citadel/resources/canonical-service/controller.yaml
@@ -318,7 +318,7 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: gcr.io/gke-release/canonical-service-controller:1.6.8-asm.6 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.canonicalServiceHub"}
+        image: gcr.io/gke-release/asm/canonical-service-controller:1.6.8-asm.9 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.canonicalServiceHub"}
         name: manager
         resources:
           limits:

--- a/asm-patch/Kptfile
+++ b/asm-patch/Kptfile
@@ -45,7 +45,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.canonicalServiceHub
-          value: gcr.io/gke-release/canonical-service-controller:1.6.8-asm.6          
+          value: gcr.io/gke-release/asm/canonical-service-controller:1.6.8-asm.9          
     io.k8s.cli.setters.anthos.servicemesh.trustDomainAliases:
       items:
         pattern: '[a-z0-9\-].svc.id.goog'

--- a/asm-patch/resources/canonical-service/controller.yaml
+++ b/asm-patch/resources/canonical-service/controller.yaml
@@ -318,7 +318,7 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: gcr.io/gke-release/canonical-service-controller:1.6.8-asm.6 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.canonicalServiceHub"}
+        image: gcr.io/gke-release/asm/canonical-service-controller:1.6.8-asm.9 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.canonicalServiceHub"}
         name: manager
         resources:
           limits:

--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -87,7 +87,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.canonicalServiceHub
-          value: gcr.io/gke-release/canonical-service-controller:1.6.8-asm.6
+          value: gcr.io/gke-release/asm/canonical-service-controller:1.6.8-asm.9
     io.k8s.cli.substitutions.mesh-id:
       type: string
       x-k8s-cli:

--- a/asm/canonical-service/controller.yaml
+++ b/asm/canonical-service/controller.yaml
@@ -318,7 +318,7 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: gcr.io/gke-release/canonical-service-controller:1.6.8-asm.6 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.canonicalServiceHub"}
+        image: gcr.io/gke-release/asm/canonical-service-controller:1.6.8-asm.9 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.canonicalServiceHub"}
         name: manager
         resources:
           limits:


### PR DESCRIPTION
Now that canonical-service-controller has been added to gke-release, I'm updating the URLs to point to the final location and version number.