### PR TITLE
Fix gcp metadata

### DIFF
--- a/asm-citadel/Kptfile
+++ b/asm-citadel/Kptfile
@@ -57,6 +57,12 @@ openAPI:
         setter:
           name: gcloud.core.project
           value: PROJECT_ID
+    io.k8s.cli.setters.gcloud.project.environProjectNumber:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: gcloud.project.environProjectNumber
+          value: PROJECT_NUMBER
     io.k8s.cli.setters.gcloud.project.projectNumber:
       type: string
       x-k8s-cli:
@@ -86,7 +92,7 @@ openAPI:
           pattern: "proj-PROJECT_NUMBER"
           values:
           - marker: PROJECT_NUMBER
-            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.projectNumber'
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectNumber'
     io.k8s.cli.substitutions.gke-metadata:
       type: string
       x-k8s-cli:

--- a/asm-patch-citadel/Kptfile
+++ b/asm-patch-citadel/Kptfile
@@ -26,6 +26,12 @@ openAPI:
         setter:
           name: gcloud.project.projectNumber
           value: PROJECT_NUMBER
+    io.k8s.cli.setters.gcloud.project.environProjectNumber:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: gcloud.project.environProjectNumber
+          value: PROJECT_NUMBER
     io.k8s.cli.setters.gcloud.compute.location:
       x-k8s-cli:
         setter:
@@ -54,7 +60,7 @@ openAPI:
           pattern: "proj-PROJECT_NUMBER"
           values:
           - marker: PROJECT_NUMBER
-            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.projectNumber'
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectNumber'
     io.k8s.cli.substitutions.gke-metadata:
       type: string
       x-k8s-cli:

--- a/asm-patch-citadel/resources/kustomization.yaml
+++ b/asm-patch-citadel/resources/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
 - istio-operator.yaml
 - enable-services.yaml
 - canonical-service/controller.yaml

--- a/asm-patch/Kptfile
+++ b/asm-patch/Kptfile
@@ -26,6 +26,12 @@ openAPI:
         setter:
           name: gcloud.project.projectNumber
           value: PROJECT_NUMBER
+    io.k8s.cli.setters.gcloud.project.environProjectNumber:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: gcloud.project.environProjectNumber
+          value: PROJECT_NUMBER
     io.k8s.cli.setters.gcloud.compute.location:
       x-k8s-cli:
         setter:
@@ -64,7 +70,7 @@ openAPI:
           pattern: "proj-PROJECT_NUMBER"
           values:
           - marker: PROJECT_NUMBER
-            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.projectNumber'
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectNumber'
     io.k8s.cli.substitutions.gke-metadata:
       type: string
       x-k8s-cli:

--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -73,11 +73,11 @@ openAPI:
         setter:
           name: gcloud.project.projectNumber
           value: PROJECT_NUMBER
-    io.k8s.cli.setters.gcloud.project.environNumber:
+    io.k8s.cli.setters.gcloud.project.environProjectNumber:
       type: string
       x-k8s-cli:
         setter:
-          name: gcloud.project.projectNumber
+          name: gcloud.project.environProjectNumber
           value: PROJECT_NUMBER
     io.k8s.cli.setters.anthos.servicemesh.hub:
       x-k8s-cli:
@@ -102,7 +102,7 @@ openAPI:
           pattern: "proj-PROJECT_NUMBER"
           values:
           - marker: PROJECT_NUMBER
-            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environNumber'
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectNumber'
     io.k8s.cli.substitutions.gke-metadata:
       type: string
       x-k8s-cli:

--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -73,6 +73,12 @@ openAPI:
         setter:
           name: gcloud.project.projectNumber
           value: PROJECT_NUMBER
+    io.k8s.cli.setters.gcloud.project.environNumber:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: gcloud.project.projectNumber
+          value: PROJECT_NUMBER
     io.k8s.cli.setters.anthos.servicemesh.hub:
       x-k8s-cli:
         setter:
@@ -96,7 +102,7 @@ openAPI:
           pattern: "proj-PROJECT_NUMBER"
           values:
           - marker: PROJECT_NUMBER
-            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.projectNumber'
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environNumber'
     io.k8s.cli.substitutions.gke-metadata:
       type: string
       x-k8s-cli:


### PR DESCRIPTION
Fix the issue where GCP_METADATA is not set properly when environ Id != project Id.

But this will introduce one more step for the current asm-gcp installation, i.e. we will need to set
kpt cfg set gcloud.project.environProjectNumber <envrion project number>