### PR TITLE
Revert "disable control plane monitoring in 1.6 for now"

### DIFF
--- a/asm-citadel/cluster/istio-operator.yaml
+++ b/asm-citadel/cluster/istio-operator.yaml
@@ -28,6 +28,8 @@ spec:
         env:
         - name: SPIFFE_BUNDLE_ENDPOINTS
           value: ""
+        - name: ENABLE_STACKDRIVER_MONITORING
+          value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
         - name: TOKEN_AUDIENCES
           value: "istio-ca,PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.token-audiences"}
   meshConfig:

--- a/asm-patch-citadel/resources/istio-operator.yaml
+++ b/asm-patch-citadel/resources/istio-operator.yaml
@@ -28,6 +28,8 @@ spec:
         env:
         - name: SPIFFE_BUNDLE_ENDPOINTS
           value: ""
+        - name: ENABLE_STACKDRIVER_MONITORING
+          value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
         - name: TOKEN_AUDIENCES
           value: "istio-ca,PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.token-audiences"}
   meshConfig:

--- a/asm-patch/resources/istio-operator.yaml
+++ b/asm-patch/resources/istio-operator.yaml
@@ -28,6 +28,8 @@ spec:
         env:
         - name: SPIFFE_BUNDLE_ENDPOINTS
           value: "PROJECT_ID.svc.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints"}
+        - name: ENABLE_STACKDRIVER_MONITORING
+          value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
   meshConfig:
     defaultConfig:
       proxyMetadata:

--- a/asm/cluster/istio-operator.yaml
+++ b/asm/cluster/istio-operator.yaml
@@ -28,6 +28,8 @@ spec:
         env:
         - name: SPIFFE_BUNDLE_ENDPOINTS
           value: "PROJECT_ID.svc.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints"}
+        - name: ENABLE_STACKDRIVER_MONITORING
+          value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
   meshConfig:
     defaultConfig:
       proxyMetadata:


### PR DESCRIPTION
Reverts GoogleCloudPlatform/anthos-service-mesh-packages#116

Brings back control plane monitoring, since current image has this function ready.