### PR TITLE
Set caAddress to emtpy to be able to support both revision and non-re…

### DIFF
--- a/asm-citadel/cluster/istio-operator.yaml
+++ b/asm-citadel/cluster/istio-operator.yaml
@@ -44,7 +44,7 @@ spec:
     global:
       meshID: "proj-PROJECT_NUMBER" # {"$ref":"#/definitions/io.k8s.cli.substitutions.mesh-id"}
       trustDomain: "cluster.local"
-      caAddress: "istiod.istio-system.svc:15012"
+      caAddress: ""
       pilotCertProvider: "istiod"
       # Enable SDS
       sds:

--- a/asm-patch-citadel/resources/istio-operator.yaml
+++ b/asm-patch-citadel/resources/istio-operator.yaml
@@ -44,7 +44,7 @@ spec:
     global:
       meshID: "proj-PROJECT_NUMBER" # {"$ref":"#/definitions/io.k8s.cli.substitutions.mesh-id"}
       trustDomain: "cluster.local"
-      caAddress: "istiod.istio-system.svc:15012"
+      caAddress: ""
       pilotCertProvider: "istiod"
       # Enable SDS
       sds:


### PR DESCRIPTION
Set caAddress to emtpy to be able to support both revision and non-revision use cases.

The template in charts will choose the right CA address based on whether revision is set or not.