### PR TITLE
Add option for Hub IDNS with MeshCA in GCP

### DIFF
--- a/asm-patch/Kptfile
+++ b/asm-patch/Kptfile
@@ -41,7 +41,7 @@ openAPI:
           value: REGULAR
     io.k8s.cli.setters.anthos.servicemesh.trustDomainAliases:
       items:
-        pattern: '[a-z0-9\-].svc.id.goog'
+        pattern: '[a-z0-9\-].(svc|hub).id.goog'
         type: string
       minItems: 1
       type: array
@@ -78,6 +78,12 @@ openAPI:
         setter:
           name: gcloud.project.environProjectNumber
           value: PROJECT_NUMBER
+    io.k8s.cli.setters.gcloud.project.environProjectID:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: gcloud.project.environProjectID
+          value: ENVIRON_PROJECT_ID
     io.k8s.cli.setters.gcloud.compute.location:
       x-k8s-cli:
         setter:
@@ -98,6 +104,12 @@ openAPI:
         setter:
           name: anthos.servicemesh.canonicalServiceHub
           value: gcr.io/gke-release/asm/canonical-service-controller:1.6.8-asm.9
+    io.k8s.cli.setters.anthos.servicemesh.hubMembershipID:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: anthos.servicemesh.hubMembershipID
+          value: MEMBERSHIP_ID
     io.k8s.cli.substitutions.mesh-id:
       type: string
       x-k8s-cli:
@@ -197,3 +209,31 @@ openAPI:
         setter:
           name: anthos.servicemesh.controlplane.monitoring.enabled
           value: "true"
+    io.k8s.cli.substitutions.spiffe-bundle-endpoints-hub:
+      x-k8s-cli:
+        substitution:
+          name: spiffe-bundle-endpoints-hub
+          pattern: ENVIRON_PROJECT_ID.hub.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json
+          values:
+          - marker: ENVIRON_PROJECT_ID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'
+    io.k8s.cli.substitutions.hub-idp-url:
+      type: string
+      x-k8s-cli:
+        substitution:
+          name: hub-idp-url
+          pattern: "https://gkehub.googleapis.com/projects/ENVIRON_PROJECT_ID/locations/global/memberships/MEMBERSHIP_ID"
+          values:
+          - marker: ENVIRON_PROJECT_ID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'
+          - marker: MEMBERSHIP_ID
+            ref: '#/definitions/io.k8s.cli.setters.anthos.servicemesh.hubMembershipID'
+    io.k8s.cli.substitutions.trust-domain-hub:
+      type: string
+      x-k8s-cli:
+        substitution:
+          name: trust-domain-hub
+          pattern: "ENVIRON_PROJECT_ID.hub.id.goog"
+          values:
+          - marker: ENVIRON_PROJECT_ID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'

--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -41,7 +41,7 @@ openAPI:
           value: REGULAR
     io.k8s.cli.setters.anthos.servicemesh.trustDomainAliases:
       items:
-        pattern: '[a-z0-9\-].svc.id.goog'
+        pattern: '[a-z0-9\-].(svc|hub).id.goog'
         type: string
       minItems: 1
       type: array
@@ -78,6 +78,12 @@ openAPI:
         setter:
           name: gcloud.project.environProjectNumber
           value: PROJECT_NUMBER
+    io.k8s.cli.setters.gcloud.project.environProjectID:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: gcloud.project.environProjectID
+          value: ENVIRON_PROJECT_ID
     io.k8s.cli.setters.gcloud.compute.location:
       x-k8s-cli:
         setter:
@@ -97,7 +103,13 @@ openAPI:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.canonicalServiceHub
-          value: gcr.io/gke-release/asm/canonical-service-controller:1.6.8-asm.9          
+          value: gcr.io/gke-release/asm/canonical-service-controller:1.6.8-asm.9
+    io.k8s.cli.setters.anthos.servicemesh.hubMembershipID:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: anthos.servicemesh.hubMembershipID
+          value: MEMBERSHIP_ID
     io.k8s.cli.substitutions.mesh-id:
       type: string
       x-k8s-cli:
@@ -197,3 +209,31 @@ openAPI:
         setter:
           name: anthos.servicemesh.controlplane.monitoring.enabled
           value: "true"
+    io.k8s.cli.substitutions.spiffe-bundle-endpoints-hub:
+      x-k8s-cli:
+        substitution:
+          name: spiffe-bundle-endpoints-hub
+          pattern: ENVIRON_PROJECT_ID.hub.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json
+          values:
+          - marker: ENVIRON_PROJECT_ID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'
+    io.k8s.cli.substitutions.hub-idp-url:
+      type: string
+      x-k8s-cli:
+        substitution:
+          name: hub-idp-url
+          pattern: "https://gkehub.googleapis.com/projects/ENVIRON_PROJECT_ID/locations/global/memberships/MEMBERSHIP_ID"
+          values:
+          - marker: ENVIRON_PROJECT_ID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'
+          - marker: MEMBERSHIP_ID
+            ref: '#/definitions/io.k8s.cli.setters.anthos.servicemesh.hubMembershipID'
+    io.k8s.cli.substitutions.trust-domain-hub:
+      type: string
+      x-k8s-cli:
+        substitution:
+          name: trust-domain-hub
+          pattern: "ENVIRON_PROJECT_ID.hub.id.goog"
+          values:
+          - marker: ENVIRON_PROJECT_ID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'

--- a/asm/istio/options/hub-meshca.yaml
+++ b/asm/istio/options/hub-meshca.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    pilot:
+      k8s:
+        env:
+          - name: SPIFFE_BUNDLE_ENDPOINTS
+            value: "ENVIRON_PROJECT_ID.hub.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints-hub"}
+          - name: ENABLE_STACKDRIVER_MONITORING
+            value: "false" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        TRUST_DOMAIN: "ENVIRON_PROJECT_ID.hub.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}
+        GKE_CLUSTER_URL: "https://gkehub.googleapis.com/projects/ENVIRON_PROJECT_ID/locations/global/memberships/MEMBERSHIP_ID" # {"$ref":"#/definitions/io.k8s.cli.substitutions.hub-idp-url"}
+    trustDomainAliases: # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.trustDomainAliases"}
+      - "ENVIRON_PROJECT_ID.hub.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}
+  values:
+    global:
+      trustDomain: "ENVIRON_PROJECT_ID.hub.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}
+      # Enable SDS
+      sds:
+        token:
+          aud: "ENVIRON_PROJECT_ID.hub.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}

--- a/pkg/Kptfile
+++ b/pkg/Kptfile
@@ -41,7 +41,7 @@ openAPI:
           value: REGULAR
     io.k8s.cli.setters.anthos.servicemesh.trustDomainAliases:
       items:
-        pattern: '[a-z0-9\-].svc.id.goog'
+        pattern: '[a-z0-9\-].(svc|hub).id.goog'
         type: string
       minItems: 1
       type: array
@@ -78,6 +78,12 @@ openAPI:
         setter:
           name: gcloud.project.environProjectNumber
           value: PROJECT_NUMBER
+    io.k8s.cli.setters.gcloud.project.environProjectID:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: gcloud.project.environProjectID
+          value: ENVIRON_PROJECT_ID
     io.k8s.cli.setters.gcloud.compute.location:
       x-k8s-cli:
         setter:
@@ -93,6 +99,12 @@ openAPI:
         setter:
           name: anthos.servicemesh.tag
           value: 1.6.8-asm.9
+    io.k8s.cli.setters.anthos.servicemesh.hubMembershipID:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: anthos.servicemesh.hubMembershipID
+          value: MEMBERSHIP_ID
     io.k8s.cli.substitutions.mesh-id:
       type: string
       x-k8s-cli:
@@ -192,3 +204,31 @@ openAPI:
         setter:
           name: anthos.servicemesh.controlplane.monitoring.enabled
           value: "true"
+    io.k8s.cli.substitutions.spiffe-bundle-endpoints-hub:
+      x-k8s-cli:
+        substitution:
+          name: spiffe-bundle-endpoints-hub
+          pattern: ENVIRON_PROJECT_ID.hub.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json
+          values:
+          - marker: ENVIRON_PROJECT_ID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'
+    io.k8s.cli.substitutions.hub-idp-url:
+      type: string
+      x-k8s-cli:
+        substitution:
+          name: hub-idp-url
+          pattern: "https://gkehub.googleapis.com/projects/ENVIRON_PROJECT_ID/locations/global/memberships/MEMBERSHIP_ID"
+          values:
+          - marker: ENVIRON_PROJECT_ID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'
+          - marker: MEMBERSHIP_ID
+            ref: '#/definitions/io.k8s.cli.setters.anthos.servicemesh.hubMembershipID'
+    io.k8s.cli.substitutions.trust-domain-hub:
+      type: string
+      x-k8s-cli:
+        substitution:
+          name: trust-domain-hub
+          pattern: "ENVIRON_PROJECT_ID.hub.id.goog"
+          values:
+          - marker: ENVIRON_PROJECT_ID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'

--- a/pkg/istio/options/hub-meshca.yaml
+++ b/pkg/istio/options/hub-meshca.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    pilot:
+      k8s:
+        env:
+          - name: SPIFFE_BUNDLE_ENDPOINTS
+            value: "ENVIRON_PROJECT_ID.hub.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints-hub"}
+          - name: ENABLE_STACKDRIVER_MONITORING
+            value: "false" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        TRUST_DOMAIN: "ENVIRON_PROJECT_ID.hub.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}
+        GKE_CLUSTER_URL: "https://gkehub.googleapis.com/projects/ENVIRON_PROJECT_ID/locations/global/memberships/MEMBERSHIP_ID" # {"$ref":"#/definitions/io.k8s.cli.substitutions.hub-idp-url"}
+    trustDomainAliases: # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.trustDomainAliases"}
+      - "ENVIRON_PROJECT_ID.hub.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}
+  values:
+    global:
+      trustDomain: "ENVIRON_PROJECT_ID.hub.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}
+      # Enable SDS
+      sds:
+        token:
+          aud: "ENVIRON_PROJECT_ID.hub.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}

--- a/pkg/istio/options/hub-meshca.yaml
+++ b/pkg/istio/options/hub-meshca.yaml
@@ -21,6 +21,8 @@ spec:
         env:
           - name: SPIFFE_BUNDLE_ENDPOINTS
             value: "ENVIRON_PROJECT_ID.hub.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints-hub"}
+          # Stackdriver is disabled because it does not support Hub IDNS currently.
+          # TODO: Enable Stackdriver monitoring when it supports Hub IDNS
           - name: ENABLE_STACKDRIVER_MONITORING
             value: "false" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
   meshConfig:


### PR DESCRIPTION
This adds an option for `ASM + Hub IDNS + MeshCA` installation. 

- It adds an option file `hub-meshca.yaml` for Hub IDNS + MeshCA.

- It adds extra setters and substitutions specifically for Hub IDNS. No original setters or substitutions are changed except trustDomainAlias to support Hub pattern.

- It does not enable stackdriver currently as stackdriver does not support Hub IDNS. 

## Commands Sample
### Single Cluster Single Project
```
# latest in repo
gcloud config set project ${PROJECT_ID}
kpt pkg get https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages.git/asm@master asm

# extra commands compared to latest in repo
kpt cfg set asm gcloud.project.environProjectID ${ENVIRON_PROJECT_ID}
kpt cfg set asm anthos.servicemesh.hubMembershipID ${HUB_MEMBERSHIP_ID}

istioctl install -f asm/istio/istio-operator.yaml -f asm/istio/options/hub-meshca.yaml
```
### Multi Clusters Single Project
```
# latest in repo
gcloud config set project ${PROJECT_ID}
kpt pkg get https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages.git/asm@master asm
kpt cfg set asm gcloud.compute.location ${CLUSTER_LOCATION}
kpt cfg set asm gcloud.container.cluster ${CLUSTER_NAME}

# extra commands compared to latest in repo
kpt cfg set asm gcloud.project.environProjectID ${ENVIRON_PROJECT_ID}
kpt cfg set asm anthos.servicemesh.hubMembershipID ${HUB_MEMBERSHIP_ID}

istioctl install -f asm/istio/istio-operator.yaml -f asm/istio/options/multicluster.yaml -f asm/istio/options/hub-meshca.yaml
``` 
### Multi Clusters Multi Projects
```
# latest in repo
gcloud config set project ${PROJECT_ID}
kpt pkg get https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages.git/asm@master asm
kpt cfg set asm gcloud.compute.location ${CLUSTER_LOCATION}
kpt cfg set asm gcloud.container.cluster ${CLUSTER_NAME}
kpt cfg set asm gcloud.project.environProjectNumber ${ENVIRON_PROJECT_NUMBER}

# not required for single environ/Hub
kpt cfg set asm anthos.servicemesh.trustDomainAliases ${SOME_TRUST_DOMAIN}

# extra commands compared to latest in repo
kpt cfg set asm gcloud.project.environProjectID ${ENVIRON_PROJECT_ID}
kpt cfg set asm anthos.servicemesh.hubMembershipID ${HUB_MEMBERSHIP_ID}

istioctl install -f asm/istio/istio-operator.yaml -f asm/istio/options/multicluster.yaml -f asm/istio/options/multiproject.yaml -f asm/istio/options/hub-meshca.yaml
```