### PR TITLE
Allow flexibility in ASM version for testing

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -14,12 +14,22 @@ else
 fi
 
 ### Internal variables ###
-MAJOR="1"; MINOR="6"; POINT="8"; REV="9";
+MAJOR="${MAJOR:=1}"
+MINOR="${MINOR:=6}"
+POINT="${POINT:=8}"
+REV="${REV:=9}"
 RELEASE="${MAJOR}.${MINOR}.${POINT}-asm.${REV}"
 RELEASE_LINE="${MAJOR}.${MINOR}."
 REVISION_LABEL="asm-${MAJOR}${MINOR}${POINT}-${REV}"
+KPT_BRANCH="release-${MAJOR}.${MINOR}-asm"
 unset MAJOR; unset MINOR; unset POINT; unset REV;
-readonly RELEASE; readonly RELEASE_LINE; readonly REVISION_LABEL;
+readonly RELEASE; readonly RELEASE_LINE; readonly REVISION_LABEL; readonly KPT_BRANCH;
+
+### These are hooks for Cloud Build to be able to use debug/staging images
+### when necessary. Don't set these environment variables unless you're testing
+### in CI/CD.
+_CI_ASM_IMAGE_LOCATION="${_CI_ASM_IMAGE_LOCATION:=}"
+_CI_ASM_PKG_LOCATION="${_CI_ASM_PKG_LOCATION:=}"
 
 ### File related constants ###
 ISTIO_FOLDER_NAME="istio-${RELEASE}"; readonly ISTIO_FOLDER_NAME;
@@ -389,7 +399,7 @@ set_kpt_package_url() {
     CA_OPT="-citadel"
   fi
   KPT_URL="https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages"
-  KPT_URL="${KPT_URL}.git/asm${CA_OPT}@release-1.6-asm"
+  KPT_URL="${KPT_URL}.git/asm${CA_OPT}@${KPT_BRANCH}"
   readonly KPT_URL;
 }
 
@@ -434,10 +444,6 @@ cleanup_local_workspace() {
 ### Environment validation functions ###
 validate_dependencies() {
   validate_cli_dependencies
-
-  if is_sa; then
-    auth_service_account
-  fi
 
   validate_gcp_resources
   # configure kubectl does have side effects but we've generated a temprorary
@@ -495,13 +501,31 @@ EOF
     *     ) fatal "$(uname) is not a supported OS.";;
   esac
 
+  if is_sa; then
+    auth_service_account
+  fi
+
   if ! necessary_files_exist; then
     info "Downloading ASM.."
-    curl -L "https://storage.googleapis.com/gke-release/asm/istio-${RELEASE}-${OS}.tar.gz" \
-      | tar xz
+    download_asm "${OS}"
 
     info "Downloading ASM kpt package..."
     retry 3 run kpt pkg get "${KPT_URL}" asm
+  fi
+}
+
+download_asm() {
+  local OS; OS="${1}";
+  local TARBALL; TARBALL="istio-${RELEASE}-${OS}.tar.gz"
+  if [[ -z "${_CI_ASM_PKG_LOCATION}" ]]; then
+    curl -L "https://storage.googleapis.com/gke-release/asm/${TARBALL}" \
+      | tar xz
+  else
+    local TOKEN; TOKEN="$(retry 2 gcloud --project="${PROJECT_ID}" auth print-access-token)"
+    run curl -L "https://storage.googleapis.com/${_CI_ASM_PKG_LOCATION}/asm/${TARBALL}" \
+      --header @- <<EOF | tar xz
+Authorization: Bearer ${TOKEN}
+EOF
   fi
 }
 
@@ -878,6 +902,10 @@ install_asm(){
   run kpt cfg set asm gcloud.core.project "${PROJECT_ID}"
   run kpt cfg set asm gcloud.project.environProjectNumber "${PROJECT_NUMBER}"
   run kpt cfg set asm gcloud.compute.location "${CLUSTER_LOCATION}"
+  if [[ -n "${_CI_ASM_IMAGE_LOCATION}" ]]; then
+    run kpt cfg set asm anthos.servicemesh.hub "${_CI_ASM_IMAGE_LOCATION}"
+    run kpt cfg set asm anthos.servicemesh.tag "${RELEASE}"
+  fi
 
   local PARAMS
   PARAMS="-f ${OPERATOR_MANIFEST}"


### PR DESCRIPTION
Parameterize version, image, and package location to allow customization of CI pipelines
Allow passing credentials when downloading ASM package to allow SAs access
Minor refactorings to support the above