### PR TITLE
Allow multiple operator overlays

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -42,6 +42,7 @@ SCRIPT_NAME="${0##*/}"
 PROJECT_NUMBER=""
 KPT_URL=""
 KUBECONFIG=""
+ABS_OVERLAYS=""
 
 ### Option variables ###
 PROJECT_ID="${PROJECT_ID:=}"
@@ -193,7 +194,8 @@ OPTIONS:
   -o|--operator_overlay  <FILE PATH>  The location of a YAML file to overlay on
                                       the ASM IstioOperator. This option can be
                                       omitted if not installing optional
-                                      features.
+                                      features. To add multiple files, specify
+                                      them with multiple options one at a time.
   -s|--service_account   <ACCOUNT>    The name of a service account used to
                                       install ASM. If not specified, the gcloud
                                       user currently configured will be used.
@@ -272,7 +274,7 @@ parse_args() {
         ;;
       -o | --operator_overlay | --operator-overlay)
         arg_required "${@}"
-        OPERATOR_OVERLAY="${2}"
+        OPERATOR_OVERLAY="${2},${OPERATOR_OVERLAY}"
         shift 2
         ;;
       -e | --enable_apis | --enable-apis)
@@ -382,12 +384,19 @@ EOF
     fatal "Couldn't find key file ${KEY_FILE}."
   fi
 
-  if [[ -f "${OPERATOR_OVERLAY}" ]]; then
-    OPERATOR_OVERLAY="$(readlink -f "${OPERATOR_OVERLAY}")"
-    readonly OPERATOR_OVERLAY
-  elif [[ -n "${OPERATOR_OVERLAY}" ]]; then
-    fatal "Couldn't find yaml file ${OPERATOR_OVERLAY}."
+  while read -d ',' -r yaml_file; do
+    if [[ -f "${yaml_file}" ]]; then
+      ABS_OVERLAYS="$(readlink -f "${yaml_file}"),${ABS_OVERLAYS}"
+    elif [[ -n "${yaml_file}" ]]; then
+      fatal "Couldn't find yaml file ${yaml_file}."
+    fi
+  done <<EOF
+${OPERATOR_OVERLAY}
+EOF
+  if [[ "${CA}" = "citadel" ]]; then
+    ABS_OVERLAYS="${PACKAGE_DIRECTORY}/options/citadel-ca.yaml,${ABS_OVERLAYS}"
   fi
+  OPERATOR_OVERLAY="${ABS_OVERLAYS}"; readonly OPERATOR_OVERLAY;
 
   set_kpt_package_url
   WORKLOAD_POOL="${PROJECT_ID}.svc.id.goog"
@@ -892,12 +901,12 @@ install_asm(){
 
   local PARAMS
   PARAMS="-f ${OPERATOR_MANIFEST}"
-  if [[ "${CA}" = "citadel" ]]; then
-    PARAMS="${PARAMS} -f ${PACKAGE_DIRECTORY}/options/citadel-ca.yaml"
-  fi
-  if [[  -f "$OPERATOR_OVERLAY" ]]; then
-    PARAMS="${PARAMS} -f ${OPERATOR_OVERLAY}"
-  fi
+  while read -d ',' -r yaml_file; do
+    PARAMS="${PARAMS} -f ${yaml_file}"
+  done <<EOF
+${OPERATOR_OVERLAY}
+EOF
+
   PARAMS="${PARAMS} --set revision=${REVISION_LABEL}"
   PARAMS="${PARAMS} -c ${KUBECONFIG}"
 

--- a/scripts/asm-installer/tests/run_cli_tests
+++ b/scripts/asm-installer/tests/run_cli_tests
@@ -75,7 +75,7 @@ test_main() {
   CMD="${CMD} -n this_should_pass"
   CMD="${CMD} -p this_should_pass"
   CMD="${CMD} -m install"
-  CMD="${CMD} -c citadel"
+  CMD="${CMD} -c mesh_ca"
   CMD="${CMD} -e --only_validate"
 
   RETVAL=0
@@ -97,7 +97,7 @@ test_main() {
   CMD="${CMD} -n this_should_pass"
   CMD="${CMD} -p this_should_fail"
   CMD="${CMD} -m install"
-  CMD="${CMD} -c citadel"
+  CMD="${CMD} -c mesh_ca"
   CMD="${CMD} -e --only-validate"
 
   RETVAL=0
@@ -120,7 +120,7 @@ test_main() {
   CMD="${CMD} -n this_should_fail"
   CMD="${CMD} -p this_should_pass"
   CMD="${CMD} -m install"
-  CMD="${CMD} -c citadel"
+  CMD="${CMD} -c mesh_ca"
   CMD="${CMD} -e --only-validate"
 
   RETVAL=0
@@ -142,7 +142,7 @@ test_main() {
   CMD="${CMD} -n this_should_pass"
   CMD="${CMD} -p this_should_pass"
   CMD="${CMD} -m this_should_fail"
-  CMD="${CMD} -c citadel"
+  CMD="${CMD} -c mesh_ca"
   CMD="${CMD} -e --only_validate"
 
   RETVAL=0
@@ -183,7 +183,7 @@ test_main() {
   CMD="${CMD} -n this_should_pass"
   CMD="${CMD} -p this_should_pass"
   CMD="${CMD} -m install"
-  CMD="${CMD} -c citadel"
+  CMD="${CMD} -c mesh_ca"
   CMD="${CMD} -s service-account"
   CMD="${CMD} -e --only_validate"
 
@@ -203,7 +203,7 @@ test_main() {
   CMD="${CMD} -n this_should_pass"
   CMD="${CMD} -p this_should_pass"
   CMD="${CMD} -m install"
-  CMD="${CMD} -c citadel"
+  CMD="${CMD} -c mesh_ca"
   CMD="${CMD} -k keyfile"
   CMD="${CMD} -e --only_validate"
 
@@ -226,7 +226,7 @@ test_main() {
   CMD="${CMD} -n this_should_pass"
   CMD="${CMD} -p this_should_pass"
   CMD="${CMD} -m install"
-  CMD="${CMD} -c citadel"
+  CMD="${CMD} -c mesh_ca"
   CMD="${CMD} -e --only_validate"
 
   RETVAL=0
@@ -248,7 +248,7 @@ test_main() {
   CMD="${CMD} -n this_should_pass"
   CMD="${CMD} -p this_should_pass"
   CMD="${CMD} -m migrate"
-  CMD="${CMD} -c citadel"
+  CMD="${CMD} -c mesh_ca"
   CMD="${CMD} -e --only_validate"
 
   RETVAL=0


### PR DESCRIPTION
 * Allow passing multiple -o options to specify multiple yaml files
 * Refactor citadel option to just add the file into the overlays instead of special casing it
 * Changed CLI tests to use meshca since validation changed location in the script