### PR TITLE
Fix node pool validation

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -16,8 +16,8 @@ fi
 ### Internal variables ###
 MAJOR="${MAJOR:=1}"
 MINOR="${MINOR:=7}"
-POINT="${POINT:=1}"
-REV="${REV:=0}"
+POINT="${POINT:=2}"
+REV="${REV:=3}"
 RELEASE="${MAJOR}.${MINOR}.${POINT}-asm.${REV}"
 RELEASE_LINE="${MAJOR}.${MINOR}."
 REVISION_LABEL="asm-${MAJOR}${MINOR}${POINT}-${REV}"
@@ -657,7 +657,12 @@ validate_node_pool() {
         (.config.machineType / "-" | .[-1] | tonumber)
       ' 2>/dev/null)" || true
 
-  if ! [[ "$ACTUAL_CPU" -ge "$TOTAL_CPU_REQ" ]]; then
+  local MAX_CPU; MAX_CPU=0;
+  for i in ${ACTUAL_CPU}; do
+    MAX_CPU="$(( i > MAX_CPU ? i : MAX_CPU))"
+  done
+
+  if [[ "$MAX_CPU" -lt "$TOTAL_CPU_REQ" ]]; then
     { read -r -d '' MSG; fatal "${MSG}"; } <<EOF || true
 ASM requires you to have at least ${TOTAL_CPU_REQ} vCPUs in node pools whose
 machine type is at least ${MACHINE_CPU_REQ} vCPUs.

--- a/scripts/asm-installer/tests/fake_gcloud
+++ b/scripts/asm-installer/tests/fake_gcloud
@@ -9,6 +9,13 @@ if [[ "${*}" == *"machineType"* ]]; then
     },
     "initialNodeCount": 4,
     "name": "default-pool"
+  },
+  {
+    "config": {
+      "machineType": "e2-medium-1"
+    },
+    "initialNodeCount": 1,
+    "name": "nondefault-pool"
   }
 ]
 EOF


### PR DESCRIPTION
 * Bump image version for staging tests
 * The validation fails if there is more than one node pool, this fixes it so that if the max CPU pool is valid then we pass