### PR TITLE
Support custom certificates for Citadel

### DIFF
--- a/scripts/asm-installer/Dockerfile
+++ b/scripts/asm-installer/Dockerfile
@@ -9,7 +9,7 @@ ENV KEY_FILE path_to_a_key_file_goes_here
 # install script dependencies
 RUN apt-get install google-cloud-sdk-kpt jq kubectl -y
 # install test dependencies
-RUN apt-get install shellcheck posh bc procps -y
+RUN apt-get install shellcheck posh bc procps openssl -y
 # copy source files into WORKDIR
 COPY install_asm ./
 COPY tests ./tests/

--- a/scripts/asm-installer/cloudbuild.yaml
+++ b/scripts/asm-installer/cloudbuild.yaml
@@ -146,6 +146,26 @@ steps:
 
 - name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
   dir: 'scripts/asm-installer'
+  id: 'run-install-custom-cert-suite'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - >
+    ./tests/run_install_custom_cert_suite
+    --PROJECT_ID "${PROJECT_ID}"
+    --BUILD_ID "${BUILD_ID}"
+    --CLUSTER_LOCATION "${_CLUSTER_LOCATION}"
+  waitFor:
+  - 'fetch-secrets'
+  env:
+  - 'SERVICE_ACCOUNT=${_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com'
+  - 'KEY_FILE=${_KEY_FILE}'
+  - '_CI_ASM_IMAGE_LOCATION=${_IMAGE_LOCATION}'
+  - '_CI_ASM_PKG_LOCATION=${_PKG_LOCATION}'
+  timeout: 2400s # 40 mins
+
+- name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
+  dir: 'scripts/asm-installer'
   id: 'run-migration-suite-meshca'
   entrypoint: '/bin/bash'
   args:

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -60,6 +60,12 @@ SERVICE_ACCOUNT="${SERVICE_ACCOUNT:=}"
 KEY_FILE="${KEY_FILE:=}"
 OUTPUT_DIR="${OUTPUT_DIR:=}"
 
+CUSTOM_CA=0
+CA_CERT="${CA_CERT:=}"
+CA_KEY="${CA_KEY:=}"
+CA_ROOT="${CA_ROOT:=}"
+CA_CHAIN="${CA_CHAIN:=}"
+
 DRY_RUN="${DRY_RUN:=0}"
 ONLY_VALIDATE="${ONLY_VALIDATE:=0}"
 VERBOSE="${VERBOSE:=0}"
@@ -89,6 +95,9 @@ main() {
     print_config >&3
     return 0
   else
+    if [[ "${CUSTOM_CA}" -eq 1 ]]; then
+      install_secrets
+    fi
     install_asm
     info "Successfully installed ASM."
   fi
@@ -202,6 +211,11 @@ OPTIONS:
   -k|--key_file          <FILE PATH>
   -D|--output_dir        <DIR PATH>
 
+  --ca_cert              <FILE PATH>
+  --ca_key               <FILE PATH>
+  --root_cert            <FILE PATH>
+  --cert_chain           <FILE PATH>
+
 FLAGS:
   -e|--enable_apis
      --print_config
@@ -257,6 +271,15 @@ OPTIONS:
                                       directory already contains the necessary
                                       files, they will be used instead of
                                       downloading them again.
+
+  The following four options must be passed together and are only necessary
+  for using a custom certificate for Citadel. Users that aren't sure whether
+  they need this probably don't.
+
+  --ca_cert              <FILE PATH>  The intermediate certificate
+  --ca_key               <FILE PATH>  The key for the intermediate certificate
+  --root_cert            <FILE PATH>  The root certificate
+  --cert_chain           <FILE PATH>  The certificate chain
 
 FLAGS:
   -e|--enable_apis                    Allow this script to enable necessary APIs
@@ -370,6 +393,30 @@ parse_args() {
         ONLY_VALIDATE=1
         shift 1
         ;;
+      --ca_cert | --ca-cert)
+        arg_required "${@}"
+        CA_CERT="${2}"
+        CUSTOM_CA=1
+        shift 2
+        ;;
+      --ca_key | --ca-key)
+        arg_required "${@}"
+        CA_KEY="${2}"
+        CUSTOM_CA=1
+        shift 2
+        ;;
+      --root_cert | --root-cert)
+        arg_required "${@}"
+        CA_ROOT="${2}"
+        CUSTOM_CA=1
+        shift 2
+        ;;
+      --cert_chain | --cert-chain)
+        arg_required "${@}"
+        CA_CHAIN="${2}"
+        CUSTOM_CA=1
+        shift 2
+        ;;
       -v)
         VERBOSE=1
         shift 1
@@ -428,6 +475,10 @@ EOF
     *) fatal "CA must be one of 'citadel', 'mesh_ca'";;
   esac
 
+  if [[ "${CUSTOM_CA}" -eq 1 ]]; then
+    validate_certs
+  fi
+
   while read -r FLAG; do
     if [[ "${!FLAG}" -ne 0 && "${!FLAG}" -ne 1 ]]; then
       fatal "${FLAG} must be 0 (off) or 1 (on) if set via environment variables."
@@ -470,6 +521,60 @@ EOF
 
   set_kpt_package_url
   WORKLOAD_POOL="${PROJECT_ID}.svc.id.goog"
+}
+
+validate_certs() {
+  if [[ "${CA}" != "citadel" ]]; then
+    fatal "You must select Citadel as the CA in order to use custom certificates."
+  fi
+  if [[ -z "${CA_ROOT}" || -z "${CA_KEY}" || -z "${CA_CHAIN}" || -z "${CA_CERT}" ]]; then
+    fatal "All four certificate options must be present to use a custom cert."
+  fi
+  while read -r CERT_FILE; do
+    if ! [[ -f "${!CERT_FILE}" ]]; then
+      fatal "Couldn't find file ${!CERT_FILE}."
+    fi
+  done <<EOF
+CA_CERT
+CA_ROOT
+CA_KEY
+CA_CHAIN
+EOF
+
+  CA_CERT="$(readlink -f "${CA_CERT}")"; readonly CA_CERT;
+  CA_KEY="$(readlink -f "${CA_KEY}")"; readonly CA_KEY;
+  CA_CHAIN="$(readlink -f "${CA_CHAIN}")"; readonly CA_CHAIN;
+  CA_ROOT="$(readlink -f "${CA_ROOT}")"; readonly CA_ROOT;
+
+  info "Checking certificate files for consistency..."
+  if ! openssl rsa -in "${CA_KEY}" -check >/dev/null 2>/dev/null; then
+    fatal "${CA_KEY} failed an openssl consistency check."
+  fi
+  if ! openssl x509 -in "${CA_CERT}" -text -noout >/dev/null; then
+    fatal "${CA_CERT} failed an openssl consistency check."
+  fi
+  if ! openssl x509 -in "${CA_CHAIN}" -text -noout >/dev/null; then
+    fatal "${CA_CHAIN} failed an openssl consistency check."
+  fi
+  if ! openssl x509 -in "${CA_ROOT}" -text -noout >/dev/null; then
+    fatal "${CA_ROOT} failed an openssl consistency check."
+  fi
+
+  info "Checking key matches certificate..."
+  local CERT_HASH; local KEY_HASH;
+  CERT_HASH="$(openssl x509 -noout -modulus -in "${CA_CERT}" | openssl md5)";
+  KEY_HASH="$(openssl rsa -noout -modulus -in "${CA_KEY}" | openssl md5)";
+  if [[ "${CERT_HASH}" != "${KEY_HASH}" ]]; then
+    fatal "Keyfile does not match the given certificate."
+    fatal "Cert: ${CA_CERT}"
+    fatal "Key: ${CA_KEY}"
+  fi
+  unset CERT_HASH; unset KEY_HASH;
+
+  info "Verifying certificate chain of trust..."
+  if ! openssl verify -trusted "${CA_ROOT}" -untrusted "${CA_CHAIN}" "${CA_CERT}"; then
+    fatal "Unable to verify chain of trust."
+  fi
 }
 
 set_kpt_package_url() {
@@ -523,7 +628,7 @@ validate_dependencies() {
   # kubeconfig so we're not breaking the promise that --only_validate gives
   configure_kubectl
   validate_expected_control_plane
-  
+
   if [[ "${MODE}" = "migrate" ]]; then
     validate_istio_version
   elif [[ "${MODE}" = "upgrade" ]]; then
@@ -557,6 +662,14 @@ kubectl
 sed
 tr
 EOF
+
+  if [[ "${CUSTOM_CA}" -eq 1 ]]; then
+    EXITCODE=0
+    hash openssl 2>/dev/null || EXITCODE=$?
+    if [[ "${EXITCODE}" -ne 0 ]]; then
+      NOTFOUND="openssl,${NOTFOUND}"
+    fi
+  fi
 
   if [[ -n "${NOTFOUND}" ]]; then
     NOTFOUND="${NOTFOUND::-1}"
@@ -1104,6 +1217,15 @@ sanitize_file() {
     -e '/^[[:space:]]*$/d' \
     -e 's/[[:space:]]*$//g' \
     "${1}"
+}
+
+install_secrets() {
+  info "Installing certificates into the cluster..."
+  run kubectl create secret generic cacerts -n istio-system \
+    --from-file="${CA_CERT}" \
+    --from-file="${CA_KEY}" \
+    --from-file="${CA_ROOT}" \
+    --from-file="${CA_CHAIN}"
 }
 
 install_asm() {

--- a/scripts/asm-installer/tests/common.sh
+++ b/scripts/asm-installer/tests/common.sh
@@ -167,6 +167,20 @@ EOF
   anneal_k8s "${NAMESPACE}"
 }
 
+install_strict_policy() {
+  local NAMESPACE; NAMESPACE="$1"
+
+  kubectl -n "${NAMESPACE}" apply -f - <<EOF
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
+metadata:
+  name: "default"
+spec:
+  mtls:
+    mode: STRICT
+EOF
+}
+
 get_demo_yaml() {
  curl -L "https://raw.githubusercontent.com/GoogleCloudPlatform/\
 microservices-demo/v0.2.0/release/${1}-manifests.yaml"

--- a/scripts/asm-installer/tests/run_install_custom_cert_suite
+++ b/scripts/asm-installer/tests/run_install_custom_cert_suite
@@ -178,7 +178,6 @@ main() {
   # Cluster teardown
   echo "Deleting cluster ${CLUSTER_NAME} and associated resources..."
   cleanup "${PROJECT_ID}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}" "${NAMESPACE}"
-  exit "$SUCCESS"
 }
 
 main "$@"

--- a/scripts/asm-installer/tests/run_install_custom_cert_suite
+++ b/scripts/asm-installer/tests/run_install_custom_cert_suite
@@ -1,0 +1,181 @@
+#!/bin/bash
+set -CeEu
+set -o pipefail
+
+SPATH="$(readlink -f "$0")"
+SDIR="$(dirname "${SPATH}")"; export SDIR;
+
+# shellcheck source=common.sh
+. "${SDIR}/common.sh"
+
+cd "${SDIR}"
+
+main() {
+  # CLI setup
+  parse_args "$@"
+
+  # Cluster setup
+  if [[ -n "${SERVICE_ACCOUNT}" ]]; then
+    echo "Authorizing service acount..."
+    auth_service_account
+  fi
+
+  local CLUSTER_NAME; CLUSTER_NAME="custom-cert-suite-${BUILD_ID::8}";
+  local NAMESPACE; NAMESPACE="namespace-${BUILD_ID}"
+  echo "Creating cluster ${CLUSTER_NAME}..."
+  create_working_cluster "${PROJECT_ID}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}"
+  # this trap isn't tested for all circumstances so caveat emptor
+  trap 'cleanup "${PROJECT_ID}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}" "${NAMESPACE}"; exit 1;' ERR
+
+  # Demo app setup
+  echo "Installing and verifying demo app..."
+  install_demo_app "${NAMESPACE}"
+
+  local GATEWAY; GATEWAY="$(kube_ingress "${NAMESPACE}")";
+  verify_demo_app "$GATEWAY"
+
+
+  echo "Generating certificates..."
+  TMP_DIR="$(mktemp -d)"
+  if [[ -z "${TMP_DIR}" ]]; then
+    fatal "Encountered error when running mktemp -d!"
+  fi
+  pushd "${TMP_DIR}"
+
+  curl -LO -H "Accept: application/vnd.github.v3.raw" \
+    https://api.github.com/repos/istio/istio/contents/tools/certs/common.mk
+  curl -LO -H "Accept: application/vnd.github.v3.raw" \
+    https://api.github.com/repos/istio/istio/contents/tools/certs/Makefile.selfsigned.mk
+
+  make -f Makefile.selfsigned.mk root-ca
+  make -f Makefile.selfsigned.mk "${CLUSTER_NAME}"-cacerts
+
+  TEST_ROOT="$(readlink -f root-cert.pem)"
+  TEST_CHAIN="$(readlink -f "${CLUSTER_NAME}"/cert-chain.pem)"
+  TEST_CERT="$(readlink -f "${CLUSTER_NAME}"/ca-cert.pem)"
+  TEST_KEY="$(readlink -f "${CLUSTER_NAME}"/ca-key.pem)"
+
+  popd
+
+  # Test starts here
+  echo "Installing ASM with custom cert Citadel..."
+  if [[ -n "${SERVICE_ACCOUNT}" ]]; then
+    echo "../install_asm \
+      -l ${CLUSTER_LOCATION} \
+      -n ${CLUSTER_NAME} \
+      -p ${PROJECT_ID} \
+      -m install \
+      -c citadel \
+      --ca-cert ${TEST_CERT} \
+      --ca-key ${TEST_KEY} \
+      --root-cert ${TEST_ROOT} \
+      --cert-chain ${TEST_CHAIN} \
+      -s ${SERVICE_ACCOUNT} \
+      -k ${KEY_FILE} -v"
+    ../install_asm \
+      -l "${CLUSTER_LOCATION}" \
+      -n "${CLUSTER_NAME}" \
+      -p "${PROJECT_ID}" \
+      -m install \
+      -c citadel \
+      --ca-cert ${TEST_CERT} \
+      --ca-key ${TEST_KEY} \
+      --root-cert ${TEST_ROOT} \
+      --cert-chain ${TEST_CHAIN} \
+      -s "${SERVICE_ACCOUNT}" \
+      -k "${KEY_FILE}" -v
+  else
+    echo "../install_asm \
+      -l ${CLUSTER_LOCATION} \
+      -n ${CLUSTER_NAME} \
+      -p ${PROJECT_ID} \
+      -m install \
+      --ca-cert ${TEST_CERT} \
+      --ca-key ${TEST_KEY} \
+      --root-cert ${TEST_ROOT} \
+      --cert-chain ${TEST_CHAIN} \
+      -c citadel -v"
+    ../install_asm \
+      -l "${CLUSTER_LOCATION}" \
+      -n "${CLUSTER_NAME}" \
+      -p "${PROJECT_ID}" \
+      -m install \
+      --ca-cert ${TEST_CERT} \
+      --ca-key ${TEST_KEY} \
+      --root-cert ${TEST_ROOT} \
+      --cert-chain ${TEST_CHAIN} \
+      -c citadel -v
+  fi
+
+  sleep 5
+  echo "Installing Istio manifests for demo app..."
+  install_demo_app_istio_manifests "${NAMESPACE}"
+  REVISION_LABEL="$(kubectl get pod -n istio-system -l app=istiod \
+      -o jsonpath='{.items[0].metadata.labels.istio\.io/rev}')"
+
+  kubectl label namespace "${NAMESPACE}" istio-injection- \
+    istio.io/rev="${REVISION_LABEL}" --overwrite || true
+
+  install_strict_policy "${NAMESPACE}"
+
+  echo "Performing a rolling restart of the demo app..."
+  roll "${NAMESPACE}"
+
+  echo "Sleeping 20 to ensure security policy is applied..."
+  sleep 20
+
+  # https://istio.io/latest/docs/tasks/security/cert-management/plugin-ca-cert/#verifying-the-certificates
+  echo "Getting current certs from running pods..."
+
+  # grab an arbitrary pod
+  CHECK_FROM="$(kubectl get pods -n "${NAMESPACE}" \
+    | grep currencyservice \
+    | awk '{ print $1 }')"
+
+  # grab an arbitrary but different IP:PORT
+  CHECK_TO="$(kubectl get service -n "${NAMESPACE}" \
+    | grep cartservice \
+    | awk '{ split($5, a, "/"); print $3 ":" a[1] }')"
+
+  pushd "${TMP_DIR}"
+  # openssl can give some weird return values sometimes
+  set +e
+  # use openssl from A to B to get the cert chain and split them into files
+  # seems like 3 is the root cert, 2 is the ca cert, 4 is the chain
+  kubectl exec -n "${NAMESPACE}" "${CHECK_FROM}" -c istio-proxy -- \
+    openssl s_client -showcerts -connect "${CHECK_TO}" \
+    | sed -n '/-----BEGIN CERTIFICATE-----/{:start /-----END CERTIFICATE-----/!{N;b start};/.*/p}' \
+    | awk 'BEGIN {counter=0;} /BEGIN CERT/{counter++} { print > "cert-" counter ".pem"}'
+
+  WANT_HASH="$(openssl x509 -in "${TEST_ROOT}" -modulus -noout)"
+  GOT_HASH="$(openssl x509 -in cert-3.pem -modulus -noout)"
+  warn "Root certificate:"
+  warn "Got: ${GOT_HASH}"
+  warn "Wanted: ${WANT_HASH}"
+  if [[ "${WANT_HASH}" != "${GOT_HASH}" ]]; then
+    fatal "Generated root certificate differs from the one from sidecar!"
+  fi
+
+  WANT_HASH="$(openssl x509 -in "${TEST_CERT}" -modulus -noout)"
+  GOT_HASH="$(openssl x509 -in cert-2.pem -modulus -noout)"
+  warn "CA certificate:"
+  warn "Got: ${GOT_HASH}"
+  warn "Wanted: ${WANT_HASH}"
+  if [[ "${WANT_HASH}" != "${GOT_HASH}" ]]; then
+    fatal "Generated CA certificate differs from the one from sidecar!"
+  fi
+
+  if ! openssl verify -trusted "${TEST_ROOT}" cert-4.pem; then
+    fatal "Couldn't verify the cert chain using generated root cert!"
+  fi
+
+  echo "Success!"
+
+
+  # Cluster teardown
+  echo "Deleting cluster ${CLUSTER_NAME} and associated resources..."
+  cleanup "${PROJECT_ID}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}" "${NAMESPACE}"
+  exit "$SUCCESS"
+}
+
+main "$@"

--- a/scripts/asm-installer/tests/run_install_custom_cert_suite
+++ b/scripts/asm-installer/tests/run_install_custom_cert_suite
@@ -140,12 +140,15 @@ main() {
   pushd "${TMP_DIR}"
   # openssl can give some weird return values sometimes
   set +e
+  set +o pipefail
   # use openssl from A to B to get the cert chain and split them into files
   # seems like 3 is the root cert, 2 is the ca cert, 4 is the chain
   kubectl exec -n "${NAMESPACE}" "${CHECK_FROM}" -c istio-proxy -- \
     openssl s_client -showcerts -connect "${CHECK_TO}" \
     | sed -n '/-----BEGIN CERTIFICATE-----/{:start /-----END CERTIFICATE-----/!{N;b start};/.*/p}' \
     | awk 'BEGIN {counter=0;} /BEGIN CERT/{counter++} { print > "cert-" counter ".pem"}'
+
+  echo "Checking certificates..."
 
   WANT_HASH="$(openssl x509 -in "${TEST_ROOT}" -modulus -noout)"
   GOT_HASH="$(openssl x509 -in cert-3.pem -modulus -noout)"


### PR DESCRIPTION
 * Add 4 long options to install_asm for custom certificate files
 * Validates openssl CLI dependency if installing a custom cert
 * Validate files exist, and passing any option requires passing all of them
 * Validate that cusom ca arguments only work with citadel
 * Validate formats of root/CA/key
 * Validate key matches CA cert 
 * Validate that chain of trust is valid for root -> CA
 * Creates the cacerts k8s secret from given files
 * Added e2e test that generates certs, installs with them, them verifies the ones from istio-proxy are the same as the ones generated
 * Added e2e test to cloudbuild