### PR TITLE
allow explicitly overriding http and status nodeports

### DIFF
--- a/asm-iap/Kptfile
+++ b/asm-iap/Kptfile
@@ -50,6 +50,20 @@ openAPI:
         setter:
           name: anthos.servicemesh.trustDomainAliases
           listValues:
+    io.k8s.cli.setters.gcloud.container.cluster.ingress.httpPort:
+      type: integer
+      x-k8s-cli:
+        setter:
+          name: gcloud.container.cluster.ingress.httpPort
+          value: 31224
+          isSet: true
+    io.k8s.cli.setters.gcloud.container.cluster.ingress.statusPort:
+      type: integer
+      x-k8s-cli:
+        setter:
+          name: gcloud.container.cluster.ingress.statusPort
+          value: 31223
+          isSet: true
     io.k8s.cli.setters.gcloud.container.cluster:
       type: string
       x-k8s-cli:

--- a/asm-iap/Kptfile
+++ b/asm-iap/Kptfile
@@ -55,14 +55,14 @@ openAPI:
       x-k8s-cli:
         setter:
           name: gcloud.container.cluster.ingress.httpPort
-          value: 31224
+          value: "31224"
           isSet: true
     io.k8s.cli.setters.gcloud.container.cluster.ingress.statusPort:
       type: integer
       x-k8s-cli:
         setter:
           name: gcloud.container.cluster.ingress.statusPort
-          value: 31223
+          value: "31223"
           isSet: true
     io.k8s.cli.setters.gcloud.container.cluster:
       type: string

--- a/asm-iap/Kptfile
+++ b/asm-iap/Kptfile
@@ -50,19 +50,19 @@ openAPI:
         setter:
           name: anthos.servicemesh.trustDomainAliases
           listValues:
-    io.k8s.cli.setters.gcloud.container.cluster.ingress.httpPort:
-      type: integer
-      x-k8s-cli:
-        setter:
-          name: gcloud.container.cluster.ingress.httpPort
-          value: "31224"
-          isSet: true
     io.k8s.cli.setters.gcloud.container.cluster.ingress.statusPort:
       type: integer
       x-k8s-cli:
         setter:
           name: gcloud.container.cluster.ingress.statusPort
           value: "31223"
+          isSet: true
+    io.k8s.cli.setters.gcloud.container.cluster.ingress.httpPort:
+      type: integer
+      x-k8s-cli:
+        setter:
+          name: gcloud.container.cluster.ingress.httpPort
+          value: "31224"
           isSet: true
     io.k8s.cli.setters.gcloud.container.cluster:
       type: string

--- a/asm-iap/cluster/istio-operator.yaml
+++ b/asm-iap/cluster/istio-operator.yaml
@@ -31,6 +31,15 @@ spec:
           type: NodePort
           ports:
             - name: status-port
+              nodePort: 31223 # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.container.cluster.ingress.statusPort"}
+              port: 15021
+              protocol: TCP
+              targetPort: 15021
+            - nodePort: 31224 # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.container.cluster.ingress.httpPort"}
+              port: 80
+              targetPort: 8080
+              name: http2
+            - name: status-port
               nodePort: 31223
               port: 15021
               protocol: TCP


### PR DESCRIPTION
This will allow users to upgrade with continuity.

Note: this doesn't currently work and I don't know why.  Running any kpt command results in the following:
`error: json: cannot unmarshal number into Go struct field setter.setter.value of type string`