### PR TITLE
Add tests for migration from previous version

### DIFF
--- a/scripts/asm-installer/cloudbuild.yaml
+++ b/scripts/asm-installer/cloudbuild.yaml
@@ -186,12 +186,52 @@ steps:
 
 - name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
   dir: 'scripts/asm-installer'
+  id: 'run-migration-suite-meshca-previous-version'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - >
+    ./tests/run_migration_suite_meshca_prev
+    --PROJECT_ID "${PROJECT_ID}"
+    --BUILD_ID "${BUILD_ID}"
+    --CLUSTER_LOCATION "${_CLUSTER_LOCATION}"
+  waitFor:
+  - 'fetch-secrets'
+  env:
+  - 'SERVICE_ACCOUNT=${_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com'
+  - 'KEY_FILE=${_KEY_FILE}'
+  - '_CI_ASM_IMAGE_LOCATION=${_IMAGE_LOCATION}'
+  - '_CI_ASM_PKG_LOCATION=${_PKG_LOCATION}'
+  timeout: 2400s # 40 mins
+
+- name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
+  dir: 'scripts/asm-installer'
   id: 'run-migration-suite-citadel'
   entrypoint: '/bin/bash'
   args:
   - '-c'
   - >
     ./tests/run_migration_suite_citadel
+    --PROJECT_ID "${PROJECT_ID}"
+    --BUILD_ID "${BUILD_ID}"
+    --CLUSTER_LOCATION "${_CLUSTER_LOCATION}"
+  waitFor:
+  - 'fetch-secrets'
+  env:
+  - 'SERVICE_ACCOUNT=${_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com'
+  - 'KEY_FILE=${_KEY_FILE}'
+  - '_CI_ASM_IMAGE_LOCATION=${_IMAGE_LOCATION}'
+  - '_CI_ASM_PKG_LOCATION=${_PKG_LOCATION}'
+  timeout: 2400s # 40 mins
+
+- name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
+  dir: 'scripts/asm-installer'
+  id: 'run-migration-suite-citadel-previous-version'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - >
+    ./tests/run_migration_suite_citadel_prev
     --PROJECT_ID "${PROJECT_ID}"
     --BUILD_ID "${BUILD_ID}"
     --CLUSTER_LOCATION "${_CLUSTER_LOCATION}"

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -940,7 +940,7 @@ validate_asm_version() {
 
 version_valid_for_upgrade() {
   local VERSION; VERSION=$1
-  
+
   # if asm version found, pattern: 1.6.11-asm.1-586f900508ad482ed32b830dd15f6c54b32b93ed
   local VERSION_MAJOR VERSION_MINOR VERSION_POINT VERSION_REV
   IFS="." read -r VERSION_MAJOR VERSION_MINOR VERSION_POINT VERSION_REV <<EOF
@@ -984,7 +984,7 @@ validate_ca_consistency() {
   info "Checking existing CA..."
   local INSTALLED_CA; INSTALLED_CA="$(kubectl -n istio-system get pod -l istio=ingressgateway \
     -o jsonpath='{.items[].spec.containers[].env[?(@.name=="CA_ADDR")].value}')"
-  
+
   local CURRENT_CA; CURRENT_CA=citadel
   if is_meshca_installed; then
     CURRENT_CA=mesh_ca

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -20,6 +20,7 @@ POINT="${POINT:=3}"
 REV="${REV:=3}"
 RELEASE="${MAJOR}.${MINOR}.${POINT}-asm.${REV}"
 RELEASE_LINE="${MAJOR}.${MINOR}."
+PREVIOUS_RELEASE_LINE="${MAJOR}.$(( MINOR - 1 ))."
 REVISION_LABEL="asm-${MAJOR}${MINOR}${POINT}-${REV}"
 KPT_BRANCH="release-${MAJOR}.${MINOR}-asm"
 readonly RELEASE; readonly RELEASE_LINE; readonly REVISION_LABEL; readonly KPT_BRANCH;
@@ -899,7 +900,7 @@ validate_istio_version() {
   fi
   local FOUND_VALID_VERSION; FOUND_VALID_VERSION=0
   for version in $(echo "${VERSION_OUTPUT}" | jq -r '.meshVersion[].Info.version' -r); do
-    if [[ "$version" =~ ^$RELEASE_LINE ]]; then
+    if [[ "$version" =~ ^$RELEASE_LINE || "$version" =~ ^$PREVIOUS_RELEASE_LINE ]]; then
       info "  $version (suitable for migration)"
       FOUND_VALID_VERSION=1
     else

--- a/scripts/asm-installer/tests/common.sh
+++ b/scripts/asm-installer/tests/common.sh
@@ -7,6 +7,7 @@ PROJECT_ID="${PROJECT_ID:=}"; export PROJECT_ID;
 CLUSTER_LOCATION="${CLUSTER_LOCATION:=us-central1-c}"; export CLUSTER_LOCATION;
 SERVICE_ACCOUNT="${SERVICE_ACCOUNT:=}"; export SERVICE_ACCOUNT;
 KEY_FILE="${KEY_FILE:=}"; export KEY_FILE;
+OSS_VERSION="${OSS_VERSION:=1.7.1}"; export OSS_VERSION;
 
 KUBECONFIG=""
 
@@ -425,9 +426,9 @@ install_oss_istio() {
   TMPDIR="$(mktemp -d)"
   pushd "${TMPDIR}"
   curl -L "https://github.com/istio/istio/releases/download/\
-1.7.1/istio-1.7.1-linux-amd64.tar.gz" | tar xz
+${OSS_VERSION}/istio-${OSS_VERSION}-linux-amd64.tar.gz" | tar xz
 
-  ./istio-1.7.1/bin/istioctl operator init
+  ./istio-"${OSS_VERSION}"/bin/istioctl operator init
   popd
   rm -r "${TMPDIR}"
 

--- a/scripts/asm-installer/tests/run_migration_suite_citadel_prev
+++ b/scripts/asm-installer/tests/run_migration_suite_citadel_prev
@@ -20,7 +20,7 @@ main() {
     auth_service_account
   fi
 
-  local CLUSTER_NAME; CLUSTER_NAME="migration-citadel-${BUILD_ID::8}";
+  local CLUSTER_NAME; CLUSTER_NAME="migration-citadel-old-${BUILD_ID::8}";
   local NAMESPACE; NAMESPACE="namespace-${BUILD_ID}"
   readonly CLUSTER_NAME
   readonly NAMESPACE

--- a/scripts/asm-installer/tests/run_migration_suite_citadel_prev
+++ b/scripts/asm-installer/tests/run_migration_suite_citadel_prev
@@ -1,0 +1,142 @@
+#!/bin/bash
+set -CeEu
+set -o pipefail
+
+SPATH="$(readlink -f "$0")"
+SDIR="$(dirname "${SPATH}")"; export SDIR;
+
+# shellcheck source=common.sh
+. "${SDIR}/common.sh"
+
+cd "${SDIR}"
+
+main() {
+  # CLI setup
+  parse_args "$@"
+
+  # Cluster setup
+  if [[ -n "${SERVICE_ACCOUNT}" ]]; then
+    echo "Authorizing service acount..."
+    auth_service_account
+  fi
+
+  local CLUSTER_NAME; CLUSTER_NAME="migration-citadel-${BUILD_ID::8}";
+  local NAMESPACE; NAMESPACE="namespace-${BUILD_ID}"
+  readonly CLUSTER_NAME
+  readonly NAMESPACE
+  echo "Creating cluster ${CLUSTER_NAME}..."
+  create_working_cluster "${PROJECT_ID}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}"
+  # this trap isn't tested for all circumstances so caveat emptor
+  trap 'cleanup "${PROJECT_ID}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}" "${NAMESPACE}"; exit 1;' ERR
+
+  # Demo app setup
+  echo "Installing and verifying demo app..."
+  install_demo_app "${NAMESPACE}"
+
+  local GATEWAY; GATEWAY="$(kube_ingress "${NAMESPACE}")";
+  verify_demo_app "$GATEWAY"
+
+  echo "Installing old OSS Istio and re-verifying demo app..."
+  OSS_VERSION="1.6.8"
+  install_oss_istio "${NAMESPACE}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}"
+
+  echo "Installing Istio manifests for demo app..."
+  install_demo_app_istio_manifests "${NAMESPACE}"
+
+  echo -n "Waiting for Istio ingress.."
+  for _ in $(seq 1 30); do
+    echo -n "."
+    GATEWAY="$(istio_ingress)"
+    [[ -n "${GATEWAY}" ]] && break || sleep 10
+  done
+  echo "."
+
+  if [[ -z "${GATEWAY}" ]]; then
+    fatal "Timed out waiting for OSS Istio ingress."
+  fi
+
+  verify_demo_app "${GATEWAY}"
+
+  # Test starts here
+
+  # Send persistent traffic to demo app to test any downtime.
+  echo "Start sending traffic to demo app"
+  send_persistent_traffic "${GATEWAY}" &
+  local SEND_TRAFFIC_CMD_PID="${!}"
+  if ! ps -p "${SEND_TRAFFIC_CMD_PID}" > /dev/null; then
+    fatal "Failed to fork child process to send traffic."
+  fi
+
+  echo "Installing ASM with Citadel..."
+  if [[ -n "${SERVICE_ACCOUNT}" ]]; then
+    echo "../install_asm \
+      -l ${CLUSTER_LOCATION} \
+      -n ${CLUSTER_NAME} \
+      -p ${PROJECT_ID} \
+      -m migrate \
+      -c citadel \
+      -s ${SERVICE_ACCOUNT} \
+      -k ${KEY_FILE} -v"
+    ../install_asm \
+      -l "${CLUSTER_LOCATION}" \
+      -n "${CLUSTER_NAME}" \
+      -p "${PROJECT_ID}" \
+      -m migrate \
+      -c citadel \
+      -s "${SERVICE_ACCOUNT}" \
+      -k "${KEY_FILE}" -v
+  else
+    echo "../install_asm \
+      -l ${CLUSTER_LOCATION} \
+      -n ${CLUSTER_NAME} \
+      -p ${PROJECT_ID} \
+      -m migrate \
+      -c citadel -v"
+    ../install_asm \
+      -l "${CLUSTER_LOCATION}" \
+      -n "${CLUSTER_NAME}" \
+      -p "${PROJECT_ID}" \
+      -m migrate \
+      -c citadel -v
+  fi
+
+  if ps -p "${SEND_TRAFFIC_CMD_PID}" > /dev/null; then
+    kill "${SEND_TRAFFIC_CMD_PID}"
+  else
+    # gcloud update can cause down time.
+    # Failing the test upon receiving unexpected response can make the test very flaky.
+    warn "Downtime detected during migration"
+  fi
+
+  sleep 5
+
+  echo "Performing a rolling restart of the demo app..."
+  roll "${NAMESPACE}"
+
+  local SUCCESS; SUCCESS=0;
+  echo "Verifying demo app via Istio ingress..."
+  GATEWAY="$(istio_ingress)"
+  set +e
+  verify_demo_app "${GATEWAY}" || SUCCESS=1
+  set -e
+
+  if [[ "${SUCCESS}" -eq 1 ]]; then
+    echo "Failed to verify, restarting and trying again..."
+    roll "${NAMESPACE}"
+
+    echo "Getting istio ingress IP..."
+    GATEWAY="$(istio_ingress)"
+    echo "Got ${GATEWAY}"
+    echo "Verifying demo app via Istio ingress..."
+    set +e
+    verify_demo_app "${GATEWAY}" || SUCCESS=1
+    set -e
+  fi
+
+  # Cluster teardown
+  echo "Deleting cluster ${CLUSTER_NAME} and associated resources..."
+  cleanup "${PROJECT_ID}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}" "${NAMESPACE}"
+  exit "$SUCCESS"
+}
+
+main "$@"

--- a/scripts/asm-installer/tests/run_migration_suite_meshca_prev
+++ b/scripts/asm-installer/tests/run_migration_suite_meshca_prev
@@ -1,0 +1,125 @@
+#!/bin/bash
+set -CeEu
+set -o pipefail
+
+SPATH="$(readlink -f "$0")"
+SDIR="$(dirname "${SPATH}")"; export SDIR;
+
+# shellcheck source=common.sh
+. "${SDIR}/common.sh"
+
+cd "${SDIR}"
+
+main() {
+  # CLI setup
+  parse_args "$@"
+
+  # Cluster setup
+  if [[ -n "${SERVICE_ACCOUNT}" ]]; then
+    echo "Authorizing service acount..."
+    auth_service_account
+  fi
+
+  local CLUSTER_NAME; CLUSTER_NAME="migration-meshca-${BUILD_ID::8}";
+  local NAMESPACE; NAMESPACE="namespace-${BUILD_ID}"
+  readonly CLUSTER_NAME
+  readonly NAMESPACE
+  echo "Creating cluster ${CLUSTER_NAME}..."
+  create_working_cluster "${PROJECT_ID}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}"
+  # this trap isn't tested for all circumstances so caveat emptor
+  trap 'cleanup "${PROJECT_ID}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}" "${NAMESPACE}"; exit 1;' ERR
+
+  # Demo app setup
+  echo "Installing and verifying demo app..."
+  install_demo_app "${NAMESPACE}"
+
+  local GATEWAY; GATEWAY="$(kube_ingress "${NAMESPACE}")";
+  verify_demo_app "$GATEWAY"
+
+  echo "Installing old OSS Istio and re-verifying demo app..."
+  OSS_VERSION="1.6.8"
+  install_oss_istio "${NAMESPACE}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}"
+
+  echo "Installing Istio manifests for demo app..."
+  install_demo_app_istio_manifests "${NAMESPACE}"
+
+  echo -n "Waiting for Istio ingress.."
+  for _ in $(seq 1 30); do
+    echo -n "."
+    GATEWAY="$(istio_ingress)"
+    [[ -n "${GATEWAY}" ]] && break || sleep 10
+  done
+  echo "."
+
+  if [[ -z "${GATEWAY}" ]]; then
+    fatal "Timed out waiting for OSS Istio ingress."
+  fi
+
+  verify_demo_app "${GATEWAY}"
+
+  # Test starts here
+  echo "Installing ASM with MeshCA..."
+  if [[ -n "${SERVICE_ACCOUNT}" ]]; then
+    echo "../install_asm \
+      -l ${CLUSTER_LOCATION} \
+      -n ${CLUSTER_NAME} \
+      -p ${PROJECT_ID} \
+      -m migrate \
+      -c mesh_ca \
+      -s ${SERVICE_ACCOUNT} \
+      -k ${KEY_FILE} -v"
+    ../install_asm \
+      -l "${CLUSTER_LOCATION}" \
+      -n "${CLUSTER_NAME}" \
+      -p "${PROJECT_ID}" \
+      -m migrate \
+      -c mesh_ca \
+      -s "${SERVICE_ACCOUNT}" \
+      -k "${KEY_FILE}" -v
+  else
+    echo "../install_asm \
+      -l ${CLUSTER_LOCATION} \
+      -n ${CLUSTER_NAME} \
+      -p ${PROJECT_ID} \
+      -m migrate \
+      -c mesh_ca -v"
+    ../install_asm \
+      -l "${CLUSTER_LOCATION}" \
+      -n "${CLUSTER_NAME}" \
+      -p "${PROJECT_ID}" \
+      -m migrate \
+      -c mesh_ca -v
+  fi
+
+  sleep 5
+
+  echo "Performing a rolling restart of the demo app..."
+  roll "${NAMESPACE}"
+
+  local SUCCESS; SUCCESS=0;
+  echo "Verifying demo app via Istio ingress..."
+  GATEWAY="$(istio_ingress)"
+  set +e
+  verify_demo_app "${GATEWAY}" || SUCCESS=1
+  set -e
+
+  if [[ "${SUCCESS}" -eq 1 ]]; then
+    echo "Failed to verify, restarting and trying again..."
+    roll "${NAMESPACE}"
+
+    echo "Getting istio ingress IP..."
+    GATEWAY="$(istio_ingress)"
+    echo "Got ${GATEWAY}"
+    echo "Verifying demo app via Istio ingress..."
+    set +e
+    verify_demo_app "${GATEWAY}" || SUCCESS=1
+    set -e
+  fi
+
+  # Cluster teardown
+  echo "Deleting cluster ${CLUSTER_NAME} and associated resources..."
+  cleanup "${PROJECT_ID}" "${CLUSTER_NAME}" "${CLUSTER_LOCATION}" "${NAMESPACE}"
+  exit "$SUCCESS"
+}
+
+main "$@"

--- a/scripts/asm-installer/tests/run_migration_suite_meshca_prev
+++ b/scripts/asm-installer/tests/run_migration_suite_meshca_prev
@@ -20,7 +20,7 @@ main() {
     auth_service_account
   fi
 
-  local CLUSTER_NAME; CLUSTER_NAME="migration-meshca-${BUILD_ID::8}";
+  local CLUSTER_NAME; CLUSTER_NAME="migration-meshca-old-${BUILD_ID::8}";
   local NAMESPACE; NAMESPACE="namespace-${BUILD_ID}"
   readonly CLUSTER_NAME
   readonly NAMESPACE


### PR DESCRIPTION
Relax the version validation a bit and add end to end tests for migration from the previous minor version of Istio.