### PR TITLE
export GKE_CLUSTER_URL to pilot for Hub overlay

### DIFF
--- a/pkg/istio/options/hub-meshca.yaml
+++ b/pkg/istio/options/hub-meshca.yaml
@@ -23,8 +23,6 @@ spec:
             value: "https://gkehub.googleapis.com/projects/ENVIRON_PROJECT_ID/locations/global/memberships/MEMBERSHIP_ID" # {"$ref":"#/definitions/io.k8s.cli.substitutions.hub-idp-url"}
           - name: SPIFFE_BUNDLE_ENDPOINTS
             value: "ENVIRON_PROJECT_ID.hub.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints-hub"}
-          # Stackdriver is disabled because it does not support Hub IDNS currently.
-          # TODO: Enable Stackdriver monitoring when it supports Hub IDNS
           - name: ENABLE_STACKDRIVER_MONITORING
             value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
   meshConfig:

--- a/pkg/istio/options/hub-meshca.yaml
+++ b/pkg/istio/options/hub-meshca.yaml
@@ -19,12 +19,14 @@ spec:
     pilot:
       k8s:
         env:
+          - name: GKE_CLUSTER_URL
+            value: "https://gkehub.googleapis.com/projects/ENVIRON_PROJECT_ID/locations/global/memberships/MEMBERSHIP_ID" # {"$ref":"#/definitions/io.k8s.cli.substitutions.hub-idp-url"}
           - name: SPIFFE_BUNDLE_ENDPOINTS
             value: "ENVIRON_PROJECT_ID.hub.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints-hub"}
           # Stackdriver is disabled because it does not support Hub IDNS currently.
           # TODO: Enable Stackdriver monitoring when it supports Hub IDNS
           - name: ENABLE_STACKDRIVER_MONITORING
-            value: "false" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
+            value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
   meshConfig:
     defaultConfig:
       proxyMetadata:


### PR DESCRIPTION
With GKE_CLUSTER_URL exported to pilot, ENABLE_STACKDRIVER_MONITORING can be enabled, which has been tested. 