### PR TITLE
Add validating webhook fix to asm-iap

### DIFF
--- a/asm-iap/Kptfile
+++ b/asm-iap/Kptfile
@@ -104,6 +104,11 @@ openAPI:
           name: anthos.servicemesh.tag
           value: 1.6.11-asm.1
           isSet: true
+    io.k8s.cli.setters.anthos.servicemesh.rev:
+      x-k8s-cli:
+        setter:
+          name: anthos.servicemesh.rev
+          value: asm-1611-1
     io.k8s.cli.setters.anthos.servicemesh.canonicalServiceHub:
       x-k8s-cli:
         setter:

--- a/asm-iap/istiod-service.yaml
+++ b/asm-iap/istiod-service.yaml
@@ -1,0 +1,45 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This YAML is intended to create an istiod service for validation to
+# work around istio/istio/issues/27501 in the case of no non-revision
+# installation.
+apiVersion: v1
+kind: Service
+metadata:
+  name: istiod
+  namespace: istio-system
+  labels:
+    istio.io/rev: asm-1611-1 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.rev"}
+    app: istiod
+    istio: pilot
+    release: istio
+spec:
+  ports:
+    - port: 15010
+      name: grpc-xds # plaintext
+      protocol: TCP
+    - port: 15012
+      name: https-dns # mTLS with k8s-signed cert
+      protocol: TCP
+    - port: 443
+      name: https-webhook # validation and injection
+      targetPort: 15017
+      protocol: TCP
+    - port: 15014
+      name: http-monitoring # prometheus stats
+      protocol: TCP
+  selector:
+    app: istiod
+    istio.io/rev: asm-1611-1 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.rev"}


### PR DESCRIPTION
This should have been in the original commit to the 1.6 release branch, and I just accidentally left it out.