### PR TITLE
allow explicitly overriding http and status nodeports (#222)

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -49,6 +49,20 @@ openAPI:
         setter:
           name: anthos.servicemesh.trustDomainAliases
           listValues:
+    io.k8s.cli.setters.gcloud.container.cluster.ingress.statusPort:
+      type: integer
+      x-k8s-cli:
+        setter:
+          name: gcloud.container.cluster.ingress.statusPort
+          value: "31223"
+          isSet: true
+    io.k8s.cli.setters.gcloud.container.cluster.ingress.httpPort:
+      type: integer
+      x-k8s-cli:
+        setter:
+          name: gcloud.container.cluster.ingress.httpPort
+          value: "31224"
+          isSet: true
     io.k8s.cli.setters.gcloud.container.cluster:
       type: string
       x-k8s-cli:

--- a/asm/istio/options/iap-operator.yaml
+++ b/asm/istio/options/iap-operator.yaml
@@ -26,11 +26,12 @@ spec:
           type: NodePort
           ports:
             - name: status-port
-              nodePort: 31223
+              nodePort: 31223 # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.container.cluster.ingress.statusPort"}
               port: 15021
               protocol: TCP
               targetPort: 15021
-            - port: 80
+            - nodePort: 31224 # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.container.cluster.ingress.httpPort"}
+              port: 80
               targetPort: 8080
               name: http2
             - port: 443


### PR DESCRIPTION
Moving around a cherry-pick of #222 onto master