### PR TITLE
Release 1.7 asm

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -47,6 +47,7 @@ SCRIPT_NAME="${0##*/}"
 PROJECT_NUMBER=""
 KPT_URL=""
 KUBECONFIG=""
+APATH=""
 ABS_OVERLAYS=""
 
 ### Option variables ###
@@ -77,6 +78,7 @@ VERBOSE="${VERBOSE:=0}"
 PRINT_HELP=0
 
 main() {
+  init
   parse_args "${@}"
   # make sure to redirect stdout as soon as possible if we're dumping the config
   if [[ "${PRINT_CONFIG}" -eq 1 ]]; then
@@ -107,6 +109,19 @@ main() {
     info "Successfully installed ASM."
   fi
   return 0
+}
+
+init() {
+  # BSD-style readlink apparently doesn't have the same -f toggle on readlink
+  case "$(uname)" in
+    Linux ) APATH="readlink";;
+    Darwin) APATH="stat";;
+    *);;
+  esac
+}
+
+apath() {
+  "${APATH}" "${@}"
 }
 
 ### Convenience functions ###
@@ -535,7 +550,7 @@ EOF
   # since we cd to a tmp directory, we need the absolute path for the key file
   # and yaml file
   if [[ -f "${KEY_FILE}" ]]; then
-    KEY_FILE="$(readlink -f "${KEY_FILE}")"
+    KEY_FILE="$(apath -f "${KEY_FILE}")"
     readonly KEY_FILE
   elif [[ -n "${KEY_FILE}" ]]; then
     fatal "Couldn't find key file ${KEY_FILE}."
@@ -543,7 +558,7 @@ EOF
 
   while read -d ',' -r yaml_file; do
     if [[ -f "${yaml_file}" ]]; then
-      ABS_OVERLAYS="$(readlink -f "${yaml_file}"),${ABS_OVERLAYS}"
+      ABS_OVERLAYS="$(apath -f "${yaml_file}"),${ABS_OVERLAYS}"
     elif [[ -n "${yaml_file}" ]]; then
       fatal "Couldn't find yaml file ${yaml_file}."
     fi
@@ -577,10 +592,10 @@ CA_KEY
 CA_CHAIN
 EOF
 
-  CA_CERT="$(readlink -f "${CA_CERT}")"; readonly CA_CERT;
-  CA_KEY="$(readlink -f "${CA_KEY}")"; readonly CA_KEY;
-  CA_CHAIN="$(readlink -f "${CA_CHAIN}")"; readonly CA_CHAIN;
-  CA_ROOT="$(readlink -f "${CA_ROOT}")"; readonly CA_ROOT;
+  CA_CERT="$(apath -f "${CA_CERT}")"; readonly CA_CERT;
+  CA_KEY="$(apath -f "${CA_KEY}")"; readonly CA_KEY;
+  CA_CHAIN="$(apath -f "${CA_CHAIN}")"; readonly CA_CHAIN;
+  CA_ROOT="$(apath -f "${CA_ROOT}")"; readonly CA_ROOT;
 
   info "Checking certificate files for consistency..."
   if ! openssl rsa -in "${CA_KEY}" -check >/dev/null 2>/dev/null; then
@@ -640,7 +655,7 @@ set_up_local_workspace() {
       fatal "Encountered error when running mktemp -d!"
     fi
   else
-    OUTPUT_DIR="$(readlink -f "${OUTPUT_DIR}")"
+    OUTPUT_DIR="$(apath -f "${OUTPUT_DIR}")"
   fi
   pushd "$OUTPUT_DIR" > /dev/null
 
@@ -747,7 +762,7 @@ EOF
     if [[ ! -f "${ABS_YAML}" ]]; then
     { read -r -d '' MSG; fatal "${MSG}"; } <<EOF || true
 Couldn't find remote yaml file ${yaml_file}.
-See directory $(readlink -f "${OPTIONS_DIRECTORY}") for available options.
+See directory $(apath -f "${OPTIONS_DIRECTORY}") for available options.
 EOF
     fi
     CUSTOM_OVERLAY="${ABS_YAML},${CUSTOM_OVERLAY}"

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1093,6 +1093,7 @@ bind_user_to_iam_policy(){
   while read -r role; do
   retry 3 run gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
     --member "${ACCOUNT_TYPE}":"${GCLOUD_MEMBER}" \
+    --condition=None \
     --role=roles/"${role}" >/dev/null
   done <<EOF
 editor

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -196,6 +196,10 @@ is_sa() {
   return 1
 }
 
+needs_asm() {
+  if [[ "${PRINT_CONFIG}" -eq 0 ]] && ! can_modify && ! should_validate; then false; fi
+}
+
 ### CLI/initial setup functions ###
 usage_short() {
   cat << EOF
@@ -1187,7 +1191,7 @@ add_cluster_labels(){
   LABELS="$(retry 2 gcloud container clusters describe "${CLUSTER_NAME}" \
     --zone="${CLUSTER_LOCATION}" \
     --project="${PROJECT_ID}" \
-    --format="value(resourceLabels)")";
+    --format='value(resourceLabels)[delimiter=","]')";
   local INSTALLER_LABEL; INSTALLER_LABEL="asmv=${RELEASE//\./-}"
   local MESH_LABEL; MESH_LABEL="mesh_id=proj-${PROJECT_NUMBER}"
   if [ "${LABELS}" ]; then


### PR DESCRIPTION
Cherry pick of three bugfixes:
  * use `stat` instead of `readlink` on Mac
  * fix the cluster label delimiter
  * fix IAM role bindings when targeting policy with existing condition