### PR TITLE
Redo PR 240 to export GKE_CLUSTER_URL to pilot for Hub overlay

### DIFF
--- a/asm/istio/options/hub-meshca.yaml
+++ b/asm/istio/options/hub-meshca.yaml
@@ -19,12 +19,12 @@ spec:
     pilot:
       k8s:
         env:
+          - name: GKE_CLUSTER_URL
+            value: "https://gkehub.googleapis.com/projects/ENVIRON_PROJECT_ID/locations/global/memberships/MEMBERSHIP_ID" # {"$ref":"#/definitions/io.k8s.cli.substitutions.hub-idp-url"}
           - name: SPIFFE_BUNDLE_ENDPOINTS
             value: "ENVIRON_PROJECT_ID.hub.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints-hub"}
-          # Stackdriver is disabled because it does not support Hub IDNS currently.
-          # TODO: Enable Stackdriver monitoring when it supports Hub IDNS
           - name: ENABLE_STACKDRIVER_MONITORING
-            value: "false" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
+            value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
   meshConfig:
     defaultConfig:
       proxyMetadata:


### PR DESCRIPTION
Same as https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/pull/240