### PR TITLE
Adding autoRepair and autoUpgrade for anthoscli new cluster creation

### DIFF
--- a/asm/cluster/nodepool.yaml
+++ b/asm/cluster/nodepool.yaml
@@ -28,5 +28,8 @@ spec:
     machineType: e2-standard-4
     workloadMetadataConfig:
       nodeMetadata: GKE_METADATA_SERVER
+  management:
+    autoRepair: true
+    autoUpgrade: true
   clusterRef:
     name: "asm-cluster" # {"$ref":"#/definitions/io.k8s.cli.setters.gcloud.container.cluster"}


### PR DESCRIPTION
Fix test failures based on new cluster creation due the changes on GKE apis.

```

Apply configs with Anthos CLI:
+ anthoscli apply -f asm/
I1121 22:11:53.170277     178 main.go:230] reconcile serviceusage.cnrm.cloud.google.com/Service compute.googleapis.com
I1121 22:11:54.562056     178 main.go:230] reconcile serviceusage.cnrm.cloud.google.com/Service container.googleapis.com
I1121 22:11:55.621076     178 main.go:230] reconcile serviceusage.cnrm.cloud.google.com/Service iamcredentials.googleapis.com
I1121 22:11:56.666956     178 main.go:230] reconcile serviceusage.cnrm.cloud.google.com/Service meshca.googleapis.com
I1121 22:11:57.766050     178 main.go:230] reconcile serviceusage.cnrm.cloud.google.com/Service meshtelemetry.googleapis.com
I1121 22:11:58.873913     178 main.go:230] reconcile serviceusage.cnrm.cloud.google.com/Service meshconfig.googleapis.com
I1121 22:11:59.930870     178 main.go:230] reconcile serviceusage.cnrm.cloud.google.com/Service anthos.googleapis.com
I1121 22:12:01.070662     178 main.go:230] reconcile container.cnrm.cloud.google.com/ContainerCluster xxxxxx

Unexpected error: error reconciling objects: error reconciling ContainerCluster:xxxxxx: error creating GKE cluster xxx: googleapi: Error 400: Auto_upgrade and auto_repair cannot be false when release_channel REGULAR is set.

```