### PR TITLE
Add CI related envs to be able to disable revision, specify image tag, and use local build istioctl

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1105,7 +1105,7 @@ check_istio_not_deployed(){
 
 validate_istio_version() {
   info "Checking existing Istio version(s)..."
-  local VERSION_OUTPUT; VERSION_OUTPUT="$(retry 3 $(istioctl_path) version -o json)"
+  local VERSION_OUTPUT; VERSION_OUTPUT="$(retry 3 "$(istioctl_path)" version -o json)"
   if [[ -z "${VERSION_OUTPUT}" ]]; then
     fatal "Couldn't validate existing Istio versions."
   fi
@@ -1128,7 +1128,7 @@ validate_istio_version() {
 
 validate_asm_version() {
   info "Checking existing ASM version(s)..."
-  local VERSION_OUTPUT; VERSION_OUTPUT="$(retry 3 $(istioctl_path) version -o json)"
+  local VERSION_OUTPUT; VERSION_OUTPUT="$(retry 3 "$(istioctl_path)" version -o json)"
   if [[ -z "${VERSION_OUTPUT}" ]]; then
     fatal "Couldn't validate existing Istio versions."
   fi
@@ -1549,7 +1549,7 @@ print_config() {
 ${CUSTOM_OVERLAY}
 EOF
   # shellcheck disable=SC2086
-  run $(istioctl_path) profile dump ${PARAMS}
+  run "$(istioctl_path)" profile dump ${PARAMS}
 }
 
 install_secrets() {
@@ -1591,7 +1591,7 @@ EOF
 
   info "Installing ASM control plane..."
   # shellcheck disable=SC2086
-  retry 5 run $(istioctl_path) install $PARAMS
+  retry 5 run "$(istioctl_path)" install $PARAMS
 
   # Prevent the stderr buffer from ^ messing up the terminal output below
   sleep 1
@@ -1600,7 +1600,7 @@ EOF
   local RAW_YAML; RAW_YAML="${REVISION_LABEL}-manifest-raw.yaml"
   local EXPANDED_YAML; EXPANDED_YAML="${REVISION_LABEL}-manifest-expanded.yaml"
   print_config > "${RAW_YAML}"
-  run $(istioctl_path) manifest generate \
+  run "$(istioctl_path)" manifest generate \
     <"${RAW_YAML}" \
     >"${EXPANDED_YAML}"
 

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -34,6 +34,7 @@ _CI_ASM_IMAGE_TAG="${_CI_ASM_IMAGE_TAG:=}"
 _CI_ASM_PKG_LOCATION="${_CI_ASM_PKG_LOCATION:=}"
 _CI_NO_VALIDATE="${_CI_NO_VALIDATE:=0}"
 _CI_NO_REVISION="${_CI_NO_REVISION:=0}"
+_CI_ISTIOCTL_REL_PATH="${_CI_ISTIOCTL_REL_PATH:=}"
 
 ### File related constants ###
 ISTIO_FOLDER_NAME="istio-${RELEASE}"; readonly ISTIO_FOLDER_NAME;
@@ -1104,7 +1105,7 @@ check_istio_not_deployed(){
 
 validate_istio_version() {
   info "Checking existing Istio version(s)..."
-  local VERSION_OUTPUT; VERSION_OUTPUT="$(retry 3 ./${ISTIOCTL_REL_PATH} version -o json)"
+  local VERSION_OUTPUT; VERSION_OUTPUT="$(retry 3 $(istioctl_path) version -o json)"
   if [[ -z "${VERSION_OUTPUT}" ]]; then
     fatal "Couldn't validate existing Istio versions."
   fi
@@ -1127,7 +1128,7 @@ validate_istio_version() {
 
 validate_asm_version() {
   info "Checking existing ASM version(s)..."
-  local VERSION_OUTPUT; VERSION_OUTPUT="$(retry 3 ./${ISTIOCTL_REL_PATH} version -o json)"
+  local VERSION_OUTPUT; VERSION_OUTPUT="$(retry 3 $(istioctl_path) version -o json)"
   if [[ -z "${VERSION_OUTPUT}" ]]; then
     fatal "Couldn't validate existing Istio versions."
   fi
@@ -1269,6 +1270,14 @@ iam_user() {
     --format="value(account)")"
 
   echo "${ACCOUNT_TYPE}:${ACCOUNT_NAME}"
+}
+
+istioctl_path() {
+  if [[ -n "${_CI_ISTIOCTL_REL_PATH}" && -f "${_CI_ISTIOCTL_REL_PATH}" ]]; then
+    echo "${_CI_ISTIOCTL_REL_PATH}"
+  else
+    echo "./${ISTIOCTL_REL_PATH}"
+  fi
 }
 
 required_iam_roles() {
@@ -1540,7 +1549,7 @@ print_config() {
 ${CUSTOM_OVERLAY}
 EOF
   # shellcheck disable=SC2086
-  run ./"${ISTIOCTL_REL_PATH}" profile dump ${PARAMS}
+  run $(istioctl_path) profile dump ${PARAMS}
 }
 
 install_secrets() {
@@ -1582,7 +1591,7 @@ EOF
 
   info "Installing ASM control plane..."
   # shellcheck disable=SC2086
-  retry 5 run ./"${ISTIOCTL_REL_PATH}" install $PARAMS
+  retry 5 run $(istioctl_path) install $PARAMS
 
   # Prevent the stderr buffer from ^ messing up the terminal output below
   sleep 1
@@ -1591,7 +1600,7 @@ EOF
   local RAW_YAML; RAW_YAML="${REVISION_LABEL}-manifest-raw.yaml"
   local EXPANDED_YAML; EXPANDED_YAML="${REVISION_LABEL}-manifest-expanded.yaml"
   print_config > "${RAW_YAML}"
-  run ./"${ISTIOCTL_REL_PATH}" manifest generate \
+  run $(istioctl_path) manifest generate \
     <"${RAW_YAML}" \
     >"${EXPANDED_YAML}"
 

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -30,7 +30,10 @@ K8S_MINOR=0
 ### when necessary. Don't set these environment variables unless you're testing
 ### in CI/CD.
 _CI_ASM_IMAGE_LOCATION="${_CI_ASM_IMAGE_LOCATION:=}"
+_CI_ASM_IMAGE_TAG="${_CI_ASM_IMAGE_TAG:=}"
 _CI_ASM_PKG_LOCATION="${_CI_ASM_PKG_LOCATION:=}"
+_CI_NO_VALIDATE="${_CI_NO_VALIDATE:=0}"
+_CI_NO_REVISION="${_CI_NO_REVISION:=0}"
 
 ### File related constants ###
 ISTIO_FOLDER_NAME="istio-${RELEASE}"; readonly ISTIO_FOLDER_NAME;
@@ -304,7 +307,7 @@ is_sa() {
 }
 
 should_validate() {
-  if [[ "${PRINT_CONFIG}" -eq 1 ]]; then false; fi
+  if [[ "${PRINT_CONFIG}" -eq 1 || "${_CI_NO_VALIDATE}" -eq 1 ]]; then false; fi
 }
 
 can_modify_at_all() {
@@ -1524,6 +1527,9 @@ configure_package() {
     run kpt cfg set asm anthos.servicemesh.hub "${_CI_ASM_IMAGE_LOCATION}"
     run kpt cfg set asm anthos.servicemesh.tag "${RELEASE}"
   fi
+  if [[ -n "${_CI_ASM_IMAGE_TAG}" ]]; then
+    run kpt cfg set asm anthos.servicemesh.tag "${_CI_ASM_IMAGE_TAG}"
+  fi
 }
 
 print_config() {
@@ -1565,7 +1571,10 @@ install_asm() {
 ${CUSTOM_OVERLAY}
 EOF
 
-  PARAMS="${PARAMS} --set revision=${REVISION_LABEL}"
+  if [[ "${_CI_NO_REVISION}" -ne 1 ]]; then
+    PARAMS="${PARAMS} --set revision=${REVISION_LABEL}"
+  fi
+
   if [[ "${K8S_MINOR}" -eq 15 ]]; then
     PARAMS="${PARAMS} -f ${BETA_CRD_MANIFEST}"
   fi


### PR DESCRIPTION
This is the effort to make scriptaro integrate with GoB test framework on 1.7.

Changes:

1. _CI_NO_REVISION disables revision-based install, because test framework on 1.7 is not able to support that (need to backport https://github.com/istio/istio/pull/28019/);
1. _CI_ASM_IMAGE_TAG  specifies image tag used for testing;
1. _CI_ISTIOCTL_REL_PATH specifies the istioctl built from the code to be tested.
1. _CI_NO_VALIDATE to skip validation because limited permissions of GoB test runner.