### PR TITLE
remove duplicate trustdomain entry

### DIFF
--- a/asm/istio/istio-operator.yaml
+++ b/asm/istio/istio-operator.yaml
@@ -35,7 +35,6 @@ spec:
         TRUST_DOMAIN: "PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
   values:
     global:
-      trustDomain: "PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
       # Enable SDS
       sds:
         token:


### PR DESCRIPTION
this is already set by the field meshConfig.defaultConfig.ProxyMetadata.TRUST_DOMAIN, not sure why we have two places here

and actually this is the reason why we saw `dulicate entry for env` error before when we use server-side apply