### PR TITLE
Prevent kpt from auto-setting, make info messages clearer

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -291,6 +291,7 @@ If this is a private cluster, verify that the correct firewall rules are applied
 https://cloud.google.com/service-mesh/docs/gke-install-overview#requirements
 EOF
   fi
+  info "kubeconfig set to ${PROJECT_ID}/${CLUSTER_LOCATION}/${CLUSTER_NAME}..."
 }
 
 warn() {
@@ -962,7 +963,7 @@ EOF
   fi
 
   info "Downloading ASM kpt package..."
-  retry 3 run kpt pkg get "${KPT_URL}" asm
+  retry 3 run kpt pkg get --auto-set=false "${KPT_URL}" asm
 }
 
 necessary_files_exist() {
@@ -1000,7 +1001,7 @@ EOF
 validate_cluster() {
   local RESULT; RESULT=""
 
-  info "Confirming cluster information..."
+  info "Confirming cluster information for ${PROJECT_ID}/${CLUSTER_LOCATION}/${CLUSTER_NAME}..."
   RESULT="$(gcloud container clusters list \
     --project="${PROJECT_ID}" \
     --filter="name = ${CLUSTER_NAME} and location = ${CLUSTER_LOCATION}" \
@@ -1049,7 +1050,7 @@ validate_node_pool() {
   local MACHINE_CPU_REQ; MACHINE_CPU_REQ=4; readonly MACHINE_CPU_REQ;
   local TOTAL_CPU_REQ; TOTAL_CPU_REQ=8; readonly TOTAL_CPU_REQ;
 
-  info "Confirming node pool requirements..."
+  info "Confirming node pool requirements for ${PROJECT_ID}/${CLUSTER_LOCATION}/${CLUSTER_NAME}..."
   local ACTUAL_CPU
   ACTUAL_CPU="$(list_valid_pools "${MACHINE_CPU_REQ}" | \
       jq '.[] |


### PR DESCRIPTION
Using the auto-set functionality is pointless since it's always overwritten anyways, and in the case that someone is installing ASM on a project different from the current gcloud configured project the messages are misleading.