### PR TITLE
Use Environ Project Number in the Hub overlay as GEK_METADATA

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -156,6 +156,21 @@ openAPI:
             ref: '#/definitions/io.k8s.cli.setters.gcloud.container.cluster'
           - marker: us-central1-c
             ref: '#/definitions/io.k8s.cli.setters.gcloud.compute.location'
+    io.k8s.cli.substitutions.gke-hub-metadata:
+      type: string
+      x-k8s-cli:
+        substitution:
+          name: gke-hub-metadata
+          pattern: "PROJECT_ID|PROJECT_NUMBER|asm-cluster|us-central1-c"
+          values:
+          - marker: PROJECT_ID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
+          - marker: PROJECT_NUMBER
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectNumber'
+          - marker: asm-cluster
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.container.cluster'
+          - marker: us-central1-c
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.compute.location'
     io.k8s.cli.substitutions.trust-domain:
       type: string
       x-k8s-cli:

--- a/asm/istio/options/hub-meshca.yaml
+++ b/asm/istio/options/hub-meshca.yaml
@@ -25,9 +25,12 @@ spec:
             value: "ENVIRON_PROJECT_ID.hub.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints-hub"}
           - name: ENABLE_STACKDRIVER_MONITORING
             value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
+          - name: GCP_METADATA
+            value: "PROJECT_ID|PROJECT_NUMBER|asm-cluster|us-central1-c" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-hub-metadata"}
   meshConfig:
     defaultConfig:
       proxyMetadata:
+        GCP_METADATA: "PROJECT_ID|PROJECT_NUMBER|asm-cluster|us-central1-c" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-hub-metadata"}
         TRUST_DOMAIN: "ENVIRON_PROJECT_ID.hub.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}
         GKE_CLUSTER_URL: "https://gkehub.googleapis.com/projects/ENVIRON_PROJECT_ID/locations/global/memberships/MEMBERSHIP_ID" # {"$ref":"#/definitions/io.k8s.cli.substitutions.hub-idp-url"}
     trustDomainAliases: # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.trustDomainAliases"}


### PR DESCRIPTION
In the case of multiproject ASM installation with Hub, clusters from different GCP projects will be registered within the same Hub of the GCP Environ project. In this case, only GCP Environ project needs to be initialized with Meshapi and we should use environProjectNumber as the PROJECT_NUBMER field of GCP_METADATA. 