### PR TITLE
Enable audit logging with ASM options overlay

### DIFF
--- a/asm/istio/options/audit-authorizationpolicy.yaml
+++ b/asm/istio/options/audit-authorizationpolicy.yaml
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    telemetry:
+      v2:
+        stackdriver:
+          configOverride:
+            enable_audit_log: true


### PR DESCRIPTION
Customer may use `--set values.telemetry.v2.stackdriver.configOverride.enable_audit_log=true` to enable AuthorizationPolicy audit logging.