### PR TITLE
Update installation script for Hub WIP to be compatible with both GKE and Hub WIP

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1371,7 +1371,8 @@ init_meshconfig() {
 ${IDENTITY}
 EOF
     info "Cluster is in the Hub of project ${ENVIRON_PROJECT_ID} with Membership ID ${HUB_MEMBERSHIP_ID}"
-    local POST_DATA; POST_DATA='{"workloadIdentityPools":["'${ENVIRON_PROJECT_ID}'.hub.id.goog"]}'
+    # Support both Hub Workload Identity Pool and GKE Workload Identity Pool.
+    local POST_DATA; POST_DATA='{"workloadIdentityPools":["'${ENVIRON_PROJECT_ID}'.hub.id.goog","'${ENVIRON_PROJECT_ID}'.svc.id.goog"]}'
     run curl --request POST --fail \
     --data "${POST_DATA}" -o /dev/null \
     "https://meshconfig.googleapis.com/v1alpha1/projects/${PROJECT_ID}:initialize" \

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1371,7 +1371,7 @@ init_meshconfig() {
 ${IDENTITY}
 EOF
     info "Cluster is in the Hub of project ${ENVIRON_PROJECT_ID} with Membership ID ${HUB_MEMBERSHIP_ID}"
-    # Support both Hub Workload Identity Pool and GKE Workload Identity Pool.
+    # initialize replaces the existing Workload Identity Pools in the IAM binding, so we need to support both Hub and GKE Workload Identity Pools
     local POST_DATA; POST_DATA='{"workloadIdentityPools":["'${ENVIRON_PROJECT_ID}'.hub.id.goog","'${ENVIRON_PROJECT_ID}'.svc.id.goog"]}'
     run curl --request POST --fail \
     --data "${POST_DATA}" -o /dev/null \


### PR DESCRIPTION
This is for the case that users have existing GKE on GCP clusters in their GCP project running mesh with GKE WIP and they want to try new mesh installation with script and Hub overlay in a new cluster of the same project. By specify both GKE and Hub WIP, we will not break existing mesh with GKE WIP.

Per discussion, we will hold off the multiproject setup for Hub at the master branch. We have a PR for master-prow branch to check the Hub multiproject setup https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/pull/310. 
