### PR TITLE
Add TOKEN_AUDIENCES field in the Hub overlay

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -189,6 +189,15 @@ openAPI:
           values:
           - marker: PROJECT_ID
             ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
+    io.k8s.cli.substitutions.token-audiences-hub:
+      type: string
+      x-k8s-cli:
+        substitution:
+          name: token-audiences-hub
+          pattern: "istio-ca,ENVIRON_PROJECT_ID.hub.id.goog"
+          values:
+          - marker: ENVIRON_PROJECT_ID
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'
     io.k8s.cli.substitutions.gke-cluster-url:
       type: string
       x-k8s-cli:

--- a/asm/istio/options/hub-meshca.yaml
+++ b/asm/istio/options/hub-meshca.yaml
@@ -27,6 +27,8 @@ spec:
             value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
           - name: GCP_METADATA
             value: "PROJECT_ID|PROJECT_NUMBER|asm-cluster|us-central1-c" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-hub-metadata"}
+          - name: TOKEN_AUDIENCES
+            value: "istio-ca,ENVIRON_PROJECT_ID.hub.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.token-audiences-hub"}
   meshConfig:
     defaultConfig:
       proxyMetadata:


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/blob/master/asm/istio/istio-operator.yaml#L29 was introduced for 1.8. Details at https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/pull/278. Thus add the corresponding field in Hub overlay. 