### PR TITLE
Use more compatible shebang

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -CeE
 set -o pipefail
 if [[ "${BASH_VERSINFO:-0}" -lt 4 ]]; then


### PR DESCRIPTION
Specifically for those running on a Mac, many people install an updated
version of bash in a different location to avoid stomping on the system
bash. This will help default to the correct shell in more environments.