### PR TITLE
Fixes for enable and only_validate

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -801,6 +801,13 @@ ONLY_VALIDATE
 VERBOSE
 EOF
 
+  if [[ "${ENABLE_ALL}" -eq 1 || "${ENABLE_CLUSTER_ROLES}" -eq 1 || \
+    "${ENABLE_CLUSTER_LABELS}" -eq 1 || "${ENABLE_GCP_APIS}" -eq 1 || \
+    "${ENABLE_GCP_IAM_ROLES}" -eq 1 || "${ENABLE_GCP_COMPONENTS}" -eq 1 ]] && \
+    [[ "${ONLY_VALIDATE}" -eq 1 ]]; then
+      fatal "The only_validate flag cannot be used with any --enable* flag"
+  fi
+
   if [[ -n "$SERVICE_ACCOUNT" && -z "$KEY_FILE" || -z "$SERVICE_ACCOUNT" && -n "$KEY_FILE" ]]; then
     fatal "Service account and key file must be used together."
   fi

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -321,7 +321,11 @@ EOF
 }
 
 warn() {
-  info "[WARNING]:${1}" >&2
+  info "[WARNING]: ${1}" >&2
+}
+
+error() {
+  info "[ERROR]: ${1}" >&2
 }
 
 info() {
@@ -329,12 +333,12 @@ info() {
 }
 
 fatal() {
-  warn "[ERROR]: ${1}"
+  error "${1}"
   exit 2
 }
 
 fatal_with_usage() {
-  warn "${1}"
+  error "${1}"
   usage_short >&2
   exit 2
 }

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -505,7 +505,8 @@ FLAGS:
   The following several flags all relate to allowing the script to create, set,
   or enable required APIs, roles, or services. These can all be performed
   manually before running the script if desired. To allow the script to perform
-  every necessary action, pass the -e|--enable_all flag.
+  every necessary action, pass the -e|--enable_all flag. All of these flags
+  are incompatible with --only_validate.
 
   -e|--enable_all                     Allow the script to perform all of the
                                       individual enable actions below.
@@ -1338,7 +1339,7 @@ exit_if_out_of_iam_policy() {
     done
     { read -r -d '' MSG; fatal "${MSG}"; } <<EOF || true
 One or more IAM roles required to install ASM is missing. Please add
-${GCLOUD_MEMBER} to the roles above, or re-run
+${GCLOUD_MEMBER} to the roles above, or run
 the script with "--enable_gcp_iam_roles" to allow the script to add
 them on your behalf.
 EOF
@@ -1432,7 +1433,7 @@ exit_if_apis_not_enabled() {
       warn "API not enabled - ${api}"
     done
     { read -r -d '' MSG; fatal "${MSG}"; } <<EOF || true
-One or more APIs are not enabled. Please enable them and retry, or re-run the
+One or more APIs are not enabled. Please enable them and retry, or run the
 script with the '--enable_gcp_apis' flag to allow the script to enable them on
 your behalf.
 EOF
@@ -1514,7 +1515,7 @@ exit_if_cluster_unlabeled() {
     done
     { read -r -d '' MSG; fatal "${MSG}"; } <<EOF || true
 One or more required cluster labels were not found. Please label them and retry,
-or re-run the script with the '--enable_cluster_labels' flag to allow the script
+or run the script with the '--enable_cluster_labels' flag to allow the script
 to enable them on your behalf.
 EOF
   fi
@@ -1579,7 +1580,7 @@ exit_if_no_workload_identity() {
   if ! is_workload_identity_enabled; then
     { read -r -d '' MSG; fatal "${MSG}"; } <<EOF || true
 Workload identity is not enabled on ${CLUSTER_NAME}. Please enable it and
-retry, or re-run the script with the '--enable_gcp_components' flag to allow
+retry, or run the script with the '--enable_gcp_components' flag to allow
 the script to enable it on your behalf.
 EOF
   fi
@@ -1614,7 +1615,7 @@ exit_if_stackdriver_not_enabled() {
   if ! is_stackdriver_enabled; then
     { read -r -d '' MSG; fatal "${MSG}"; } <<EOF || true
 Cloud Operations (Stackdriver)  is not enabled on ${CLUSTER_NAME}.
-Please enable it and retry, or re-run the script with the
+Please enable it and retry, or run the script with the
 '--enable_gcp_components' flag to allow the script to enable it on your behalf.
 EOF
   fi
@@ -1650,7 +1651,7 @@ exit_if_not_cluster_admin() {
   if ! is_user_cluster_admin; then
     { read -r -d '' MSG; fatal "${MSG}"; } <<EOF || true
 Current user must have the cluster-admin role on ${CLUSTER_NAME}.
-Please add the cluster role binding and retry, or re-run the script with the
+Please add the cluster role binding and retry, or run the script with the
 '--enable_cluster_roles' flag to allow the script to enable it on your behalf.
 EOF
   fi

--- a/scripts/asm-installer/tests/run_cli_tests
+++ b/scripts/asm-installer/tests/run_cli_tests
@@ -86,7 +86,7 @@ test_main() {
   CMD="${CMD} -p this_should_pass"
   CMD="${CMD} -m install"
   CMD="${CMD} -c mesh_ca"
-  CMD="${CMD} -e --only_validate"
+  CMD="${CMD} --only_validate"
 
   RETVAL=0
   clear_variables
@@ -108,7 +108,7 @@ test_main() {
   CMD="${CMD} -p this_should_fail"
   CMD="${CMD} -m install"
   CMD="${CMD} -c mesh_ca"
-  CMD="${CMD} -e --only-validate"
+  CMD="${CMD} --only-validate"
 
   RETVAL=0
   clear_variables
@@ -131,7 +131,7 @@ test_main() {
   CMD="${CMD} -p this_should_pass"
   CMD="${CMD} -m install"
   CMD="${CMD} -c mesh_ca"
-  CMD="${CMD} -e --only-validate"
+  CMD="${CMD} --only-validate"
 
   RETVAL=0
   clear_variables
@@ -153,7 +153,7 @@ test_main() {
   CMD="${CMD} -p this_should_pass"
   CMD="${CMD} -m this_should_fail"
   CMD="${CMD} -c mesh_ca"
-  CMD="${CMD} -e --only_validate"
+  CMD="${CMD} --only_validate"
 
   RETVAL=0
   clear_variables
@@ -172,7 +172,7 @@ test_main() {
   CMD="${CMD} -p this_should_pass"
   CMD="${CMD} -m migrate"
   CMD="${CMD} -c this_should_fail"
-  CMD="${CMD} -e --only_validate"
+  CMD="${CMD} --only_validate"
 
   RETVAL=0
   clear_variables
@@ -195,7 +195,7 @@ test_main() {
   CMD="${CMD} -m install"
   CMD="${CMD} -c mesh_ca"
   CMD="${CMD} -s service-account"
-  CMD="${CMD} -e --only_validate"
+  CMD="${CMD} --only_validate"
 
   RETVAL=0
   clear_variables
@@ -215,7 +215,7 @@ test_main() {
   CMD="${CMD} -m install"
   CMD="${CMD} -c mesh_ca"
   CMD="${CMD} -k keyfile"
-  CMD="${CMD} -e --only_validate"
+  CMD="${CMD} --only_validate"
 
   RETVAL=0
   clear_variables
@@ -237,7 +237,7 @@ test_main() {
   CMD="${CMD} -p this_should_pass"
   CMD="${CMD} -m install"
   CMD="${CMD} -c mesh_ca"
-  CMD="${CMD} -e --only_validate"
+  CMD="${CMD} --only_validate"
 
   RETVAL=0
   clear_variables
@@ -259,7 +259,7 @@ test_main() {
   CMD="${CMD} -p this_should_pass"
   CMD="${CMD} -m migrate"
   CMD="${CMD} -c mesh_ca"
-  CMD="${CMD} -e --only_validate"
+  CMD="${CMD} --only_validate"
 
   RETVAL=0
   clear_variables
@@ -269,6 +269,28 @@ test_main() {
     echo "Fails on migrating with Istio outside of istio-system: PASS"
   else
     echo "Fails on migrating with Istio outside of istio-system: FAIL"
+    ((++FAILURES))
+  fi
+
+  #################
+  # Should fail if enable* passed with only-validate
+  #################
+
+  CMD="-l this_should_pass"
+  CMD="${CMD} -n this_should_pass"
+  CMD="${CMD} -p this_should_pass"
+  CMD="${CMD} -m migrate"
+  CMD="${CMD} -c mesh_ca"
+  CMD="${CMD} -e --only_validate"
+
+  RETVAL=0
+  clear_variables
+  _="$(main ${CMD})" || RETVAL="${?}"
+
+  if [[ "${RETVAL}" -ne 0 ]]; then
+    echo "Fails on using enable* with --only-validate: PASS"
+  else
+    echo "Fails on using enable* with --only-validate: FAIL"
     ((++FAILURES))
   fi
 

--- a/scripts/asm-installer/tests/run_cli_tests
+++ b/scripts/asm-installer/tests/run_cli_tests
@@ -69,6 +69,10 @@ tar() {
   return 0
 }
 
+kpt() {
+  return 0
+}
+
 test_main() {
   local FAILURES; FAILURES=0;
 


### PR DESCRIPTION
Four things split into different commits:
 * I somehow missed that it was printing WARNING: ERROR: every time, so fixed that
 * Sped up the cli tests by mocking out kpt since we don't test it there
 * Check that only-validate isn't combined with any of the enable options in validate_cil_args
 * Clarify language around the enable flags in various places.