### PR TITLE
ILB - add correct targetPort for ports <1024

### DIFF
--- a/asm/istio/options/internal-load-balancer.yaml
+++ b/asm/istio/options/internal-load-balancer.yaml
@@ -29,6 +29,8 @@ spec:
             port: 15020
           - name: http2
             port: 80
+            targetPort: 8080
           - name: https
             port: 443
+            targetPort: 8443
 # [END docs]


### PR DESCRIPTION
With the current IstioOperator CR, the installation fails.

```
Error: failed to install manifests: generated config failed semantic validation: port http2/80 in gateway istio-ingressgateway invalid: targetPort is set to 0, which requires root. Set targetPort to be greater than 1024 or configure values.gateways.istio-ingressgateway.runAsRoot=true, port https/443 in gateway istio-ingressgateway invalid: targetPort is set to 0, which requires root. Set targetPort to be greater than 1024 or configure values.gateways.istio-ingressgateway.runAsRoot=true
```

proxyv2 identified ports:
```
Containers:
  istio-proxy:
    ...
    Ports:         15020/TCP, 8080/TCP, 8443/TCP, 15090/TCP
```