### PR TITLE
Update installation script to support ASM installation with Hub from non hosting project

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1453,17 +1453,17 @@ init_meshconfig() {
 ${IDENTITY}
 EOF
     info "Cluster has Membership ID ${HUB_MEMBERSHIP_ID} in the Hub of project ${ENVIRON_PROJECT_ID}"
-    if [[ "${ENVIRON_PROJECT_ID}" == "${PROJECT_ID}" ]]; then
-      # initialize replaces the existing Workload Identity Pools in the IAM binding, so we need to support both Hub and GKE Workload Identity Pools
-      local POST_DATA; POST_DATA='{"workloadIdentityPools":["'${ENVIRON_PROJECT_ID}'.hub.id.goog","'${ENVIRON_PROJECT_ID}'.svc.id.goog"]}'
-      run curl --request POST --fail \
-      --data "${POST_DATA}" -o /dev/null \
-      "https://meshconfig.googleapis.com/v1alpha1/projects/${PROJECT_ID}:initialize" \
-      --header "Content-Type: application/json" \
-      -K <(auth_header "$(get_auth_token)")
-    else
+    if [[ "${ENVIRON_PROJECT_ID}" != "${PROJECT_ID}" ]]; then
       info "Skip initializing meshconfig API as the Hub is not hosted in the project ${PROJECT_ID}"
+      return 0
     fi
+    # initialize replaces the existing Workload Identity Pools in the IAM binding, so we need to support both Hub and GKE Workload Identity Pools
+    local POST_DATA; POST_DATA='{"workloadIdentityPools":["'${ENVIRON_PROJECT_ID}'.hub.id.goog","'${ENVIRON_PROJECT_ID}'.svc.id.goog"]}'
+    run curl --request POST --fail \
+    --data "${POST_DATA}" -o /dev/null \
+    "https://meshconfig.googleapis.com/v1alpha1/projects/${PROJECT_ID}:initialize" \
+    --header "Content-Type: application/json" \
+    -K <(auth_header "$(get_auth_token)")
   else
     run curl --request POST --fail \
     --data '' -o /dev/null \

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1452,14 +1452,18 @@ init_meshconfig() {
     read -r ENVIRON_PROJECT_ID HUB_MEMBERSHIP_ID <<EOF
 ${IDENTITY}
 EOF
-    info "Cluster is in the Hub of project ${ENVIRON_PROJECT_ID} with Membership ID ${HUB_MEMBERSHIP_ID}"
-    # initialize replaces the existing Workload Identity Pools in the IAM binding, so we need to support both Hub and GKE Workload Identity Pools
-    local POST_DATA; POST_DATA='{"workloadIdentityPools":["'${ENVIRON_PROJECT_ID}'.hub.id.goog","'${ENVIRON_PROJECT_ID}'.svc.id.goog"]}'
-    run curl --request POST --fail \
-    --data "${POST_DATA}" -o /dev/null \
-    "https://meshconfig.googleapis.com/v1alpha1/projects/${PROJECT_ID}:initialize" \
-    --header "Content-Type: application/json" \
-    -K <(auth_header "$(get_auth_token)")
+    info "Cluster has Membership ID ${HUB_MEMBERSHIP_ID} in the Hub of project ${ENVIRON_PROJECT_ID}"
+    if [[ "${ENVIRON_PROJECT_ID}" == "${PROJECT_ID}" ]]; then
+      # initialize replaces the existing Workload Identity Pools in the IAM binding, so we need to support both Hub and GKE Workload Identity Pools
+      local POST_DATA; POST_DATA='{"workloadIdentityPools":["'${ENVIRON_PROJECT_ID}'.hub.id.goog","'${ENVIRON_PROJECT_ID}'.svc.id.goog"]}'
+      run curl --request POST --fail \
+      --data "${POST_DATA}" -o /dev/null \
+      "https://meshconfig.googleapis.com/v1alpha1/projects/${PROJECT_ID}:initialize" \
+      --header "Content-Type: application/json" \
+      -K <(auth_header "$(get_auth_token)")
+    else
+      info "Skip initializing meshconfig API as the Hub is not hosted in the project ${PROJECT_ID}"
+    fi
   else
     run curl --request POST --fail \
     --data '' -o /dev/null \


### PR DESCRIPTION
This is the manual cherry pick of https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/pull/310. https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/pull/310 has been tested in the ASM PROW CI workflows. 