### PR TITLE
Fix error when installing managed

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1823,6 +1823,8 @@ outro() {
     info "${OUTPUT_DIR}/asm"
     info "The version of istioctl that matches the installation can be found at:"
     info "${OUTPUT_DIR}/${ISTIOCTL_REL_PATH}"
+  fi
+  if ! is_managed || ! is_sa; then
     info "The combined configuration generated for installation can be found at:"
     info "${OUTPUT_DIR}/${RAW_YAML}"
     info "The full, expanded set of kubernetes resources can be found at:"


### PR DESCRIPTION
We don't generate the control plane yaml when we're installing managed, so
we shouldn't try and print it.