### PR TITLE
Properly label namespaces in migration tests

### DIFF
--- a/scripts/asm-installer/tests/common.sh
+++ b/scripts/asm-installer/tests/common.sh
@@ -169,6 +169,17 @@ EOF
   anneal_k8s "${NAMESPACE}"
 }
 
+label_with_revision() {
+  local NAMESPACE; NAMESPACE="$1"
+  local LABEL; LABEL="$2"
+
+  kubectl label \
+    namespace "${NAMESPACE}" \
+    istio-injection- \
+    "${LABEL}" \
+    --overwrite
+}
+
 install_strict_policy() {
   local NAMESPACE; NAMESPACE="$1"
 

--- a/scripts/asm-installer/tests/run_migration_suite_citadel
+++ b/scripts/asm-installer/tests/run_migration_suite_citadel
@@ -66,6 +66,8 @@ main() {
     fatal "Failed to fork child process to send traffic."
   fi
 
+  mkfifo "${CLUSTER_NAME}"
+
   echo "Installing ASM with Citadel..."
   if [[ -n "${SERVICE_ACCOUNT}" ]]; then
     echo "../install_asm \
@@ -83,7 +85,8 @@ main() {
       -m migrate \
       -c citadel \
       -s "${SERVICE_ACCOUNT}" \
-      -k "${KEY_FILE}" -v -e
+      -k "${KEY_FILE}" -v -e \
+      2>&1 | tee "${CLUSTER_NAME}" &
   else
     echo "../install_asm \
       -l ${CLUSTER_LOCATION} \
@@ -96,7 +99,8 @@ main() {
       -n "${CLUSTER_NAME}" \
       -p "${PROJECT_ID}" \
       -m migrate \
-      -c citadel -v -e
+      -c citadel -v -e \
+      2>&1 | tee "${CLUSTER_NAME}" &
   fi
 
   if ps -p "${SEND_TRAFFIC_CMD_PID}" > /dev/null; then
@@ -109,6 +113,10 @@ main() {
 
   sleep 5
 
+  LABEL="$(grep -o -m 1 'istio.io/rev=\S*' "${CLUSTER_NAME}")"
+  rm "${CLUSTER_NAME}"
+  echo "Relabelling namsepace with ${LABEL}..."
+  label_with_revision "${NAMESPACE}" "${LABEL}"
   echo "Performing a rolling restart of the demo app..."
   roll "${NAMESPACE}"
 

--- a/scripts/asm-installer/tests/run_migration_suite_citadel_prev
+++ b/scripts/asm-installer/tests/run_migration_suite_citadel_prev
@@ -67,6 +67,8 @@ main() {
     fatal "Failed to fork child process to send traffic."
   fi
 
+  mkfifo "${CLUSTER_NAME}"
+
   echo "Installing ASM with Citadel..."
   if [[ -n "${SERVICE_ACCOUNT}" ]]; then
     echo "../install_asm \
@@ -84,7 +86,8 @@ main() {
       -m migrate \
       -c citadel \
       -s "${SERVICE_ACCOUNT}" \
-      -k "${KEY_FILE}" -v -e
+      -k "${KEY_FILE}" -v -e \
+      2>&1 | tee "${CLUSTER_NAME}" &
   else
     echo "../install_asm \
       -l ${CLUSTER_LOCATION} \
@@ -97,7 +100,8 @@ main() {
       -n "${CLUSTER_NAME}" \
       -p "${PROJECT_ID}" \
       -m migrate \
-      -c citadel -v -e
+      -c citadel -v -e \
+      2>&1 | tee "${CLUSTER_NAME}" &
   fi
 
   if ps -p "${SEND_TRAFFIC_CMD_PID}" > /dev/null; then
@@ -110,6 +114,10 @@ main() {
 
   sleep 5
 
+  LABEL="$(grep -o -m 1 'istio.io/rev=\S*' "${CLUSTER_NAME}")"
+  rm "${CLUSTER_NAME}"
+  echo "Relabelling namsepace with ${LABEL}..."
+  label_with_revision "${NAMESPACE}" "${LABEL}"
   echo "Performing a rolling restart of the demo app..."
   roll "${NAMESPACE}"
 

--- a/scripts/asm-installer/tests/run_migration_suite_meshca
+++ b/scripts/asm-installer/tests/run_migration_suite_meshca
@@ -56,6 +56,8 @@ main() {
 
   verify_demo_app "${GATEWAY}"
 
+  mkfifo "${CLUSTER_NAME}"
+
   # Test starts here
   echo "Installing ASM with MeshCA..."
   if [[ -n "${SERVICE_ACCOUNT}" ]]; then
@@ -74,7 +76,8 @@ main() {
       -m migrate \
       -c mesh_ca \
       -s "${SERVICE_ACCOUNT}" \
-      -k "${KEY_FILE}" -v -e
+      -k "${KEY_FILE}" -v -e \
+      2>&1 | tee "${CLUSTER_NAME}" &
   else
     echo "../install_asm \
       -l ${CLUSTER_LOCATION} \
@@ -87,11 +90,16 @@ main() {
       -n "${CLUSTER_NAME}" \
       -p "${PROJECT_ID}" \
       -m migrate \
-      -c mesh_ca -v -e
+      -c mesh_ca -v -e \
+      2>&1 | tee "${CLUSTER_NAME}" &
   fi
 
   sleep 5
 
+  LABEL="$(grep -o -m 1 'istio.io/rev=\S*' "${CLUSTER_NAME}")"
+  rm "${CLUSTER_NAME}"
+  echo "Relabelling namsepace with ${LABEL}..."
+  label_with_revision "${NAMESPACE}" "${LABEL}"
   echo "Performing a rolling restart of the demo app..."
   roll "${NAMESPACE}"
 

--- a/scripts/asm-installer/tests/run_migration_suite_meshca_prev
+++ b/scripts/asm-installer/tests/run_migration_suite_meshca_prev
@@ -57,6 +57,8 @@ main() {
 
   verify_demo_app "${GATEWAY}"
 
+  mkfifo "${CLUSTER_NAME}"
+
   # Test starts here
   echo "Installing ASM with MeshCA..."
   if [[ -n "${SERVICE_ACCOUNT}" ]]; then
@@ -75,7 +77,8 @@ main() {
       -m migrate \
       -c mesh_ca \
       -s "${SERVICE_ACCOUNT}" \
-      -k "${KEY_FILE}" -v -e
+      -k "${KEY_FILE}" -v -e \
+      2>&1 | tee "${CLUSTER_NAME}" &
   else
     echo "../install_asm \
       -l ${CLUSTER_LOCATION} \
@@ -88,11 +91,16 @@ main() {
       -n "${CLUSTER_NAME}" \
       -p "${PROJECT_ID}" \
       -m migrate \
-      -c mesh_ca -v -e
+      -c mesh_ca -v -e \
+      2>&1 | tee "${CLUSTER_NAME}" &
   fi
 
   sleep 5
 
+  LABEL="$(grep -o -m 1 'istio.io/rev=\S*' "${CLUSTER_NAME}")"
+  rm "${CLUSTER_NAME}"
+  echo "Relabelling namsepace with ${LABEL}..."
+  label_with_revision "${NAMESPACE}" "${LABEL}"
   echo "Performing a rolling restart of the demo app..."
   roll "${NAMESPACE}"
 


### PR DESCRIPTION
For tests where we're migrating from OSS, we never re-label the
namespaces with the correct revision before doing a rolling restart.
With this PR, we put all of the script output info a FIFO and grep out
what the new label is supposed to be, and then label the namespace
properly before performing a restart of the workloads.