### PR TITLE
fix trustdomain issue

### DIFF
--- a/asm/istio/istio-operator.yaml
+++ b/asm/istio/istio-operator.yaml
@@ -29,13 +29,12 @@ spec:
         - name: TOKEN_AUDIENCES
           value: "PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.token-audiences"}
   meshConfig:
+    trustDomain: "PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
     defaultConfig:
       proxyMetadata:
         GCE_METADATA_HOST: "metadata.google.internal"
-        TRUST_DOMAIN: "PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
   values:
     global:
-      trustDomain: "PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}
       # Enable SDS
       sds:
         token:


### PR DESCRIPTION
values.global. trustDomain is deprecated in favor of meshConfig one, however we should set it under meshConfig directly instead of proxymetadata.