### PR TITLE
Using placeholder for rev and tag

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -112,13 +112,13 @@ openAPI:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.tag
-          value: 1.7.3-asm.6
+          value: ASM_IMAGE_TAG
           isSet: true
     io.k8s.cli.setters.anthos.servicemesh.rev:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.rev
-          value: asm-173-6
+          value: ASM_REV
           isSet: true
     io.k8s.cli.setters.anthos.servicemesh.canonicalServiceHub:
       x-k8s-cli:

--- a/asm/istio/istio-operator.yaml
+++ b/asm/istio/istio-operator.yaml
@@ -17,7 +17,7 @@ kind: IstioOperator
 spec:
   profile: asm-gcp
   hub: gcr.io/gke-release/asm # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.hub"}
-  tag: 1.8.1-asm.5 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.tag"}
+  tag: ASM_IMAGE_TAG # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.tag"}
   components:
     pilot:
       k8s:

--- a/asm/istio/istiod-service.yaml
+++ b/asm/istio/istiod-service.yaml
@@ -21,7 +21,7 @@ metadata:
   name: istiod
   namespace: istio-system
   labels:
-    istio.io/rev: asm-173-6 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.rev"}
+    istio.io/rev: ASM_REV # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.rev"}
     app: istiod
     istio: pilot
     release: istio
@@ -42,4 +42,4 @@ spec:
     protocol: TCP
   selector:
     app: istiod
-    istio.io/rev: asm-173-6 # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.rev"}
+    istio.io/rev: ASM_REV # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.rev"}


### PR DESCRIPTION
because install_asm will always set them just like PROJECT_ID, also reducing the work of maintaining them in sync from various places with our release version.

https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/blob/master/scripts/asm-installer/install_asm#L17-L20 will be the source of truth of the revision and version.