### PR TITLE
Apply validation fix before installation

### DIFF
--- a/scripts/asm-installer/cloudbuild.yaml
+++ b/scripts/asm-installer/cloudbuild.yaml
@@ -38,12 +38,13 @@ steps:
   entrypoint: '/bin/bash'
   args:
   - '-c'
-  - >
-    gcloud secrets versions access latest
-    --secret="${_SECRET_NAME}"
-    --format='get(payload.data)'
-    --project="${PROJECT_ID}"
-    | tr '_-' '/+'
+  - |
+    date
+    gcloud secrets versions access latest \
+    --secret="${_SECRET_NAME}" \
+    --format='get(payload.data)' \
+    --project="${PROJECT_ID}" \
+    | tr '_-' '/+' \
     | base64 -d > "${_KEY_FILE}"
   waitFor:
   - 'lint-with-shellcheck'
@@ -58,6 +59,7 @@ steps:
     set -e
     # This will delete all clusters older than 3 hours old
 
+    date
     gcloud auth activate-service-account \
       "${_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com" \
       --key-file="${_KEY_FILE}"

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1785,6 +1785,10 @@ does_istiod_exist(){
 }
 
 install_asm() {
+  if ! does_istiod_exist; then
+    info "Installing validation webhook fix..."
+    retry 3 run kubectl apply -f "${VALIDATION_FIX_SERVICE}"
+  fi
 
   local PARAMS
   PARAMS="-f ${OPERATOR_MANIFEST}"
@@ -1815,11 +1819,6 @@ EOF
   run ./"${ISTIOCTL_REL_PATH}" manifest generate \
     <"${RAW_YAML}" \
     >"${EXPANDED_YAML}"
-
-  if ! does_istiod_exist; then
-    info "Installing validation webhook fix..."
-    retry 3 run kubectl apply -f "${VALIDATION_FIX_SERVICE}"
-  fi
 
   if [[ "$DISABLE_CANONICAL_SERVICE" -eq 0 ]]; then
     info "Installing ASM CanonicalService controller in asm-system namespace..."


### PR DESCRIPTION
There are certain options that are either more difficult or impossible
to configure properly at install time without the fix applied. There
isn't any harm in applying it beforehand, so we should just do it that
way all the time.