### PR TITLE
Revamp 2

### DIFF
--- a/scripts/asm-installer/cloudbuild-master.yaml
+++ b/scripts/asm-installer/cloudbuild-master.yaml
@@ -49,6 +49,17 @@ steps:
   waitFor:
   - 'lint-with-shellcheck'
 
+- name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
+  dir: 'scripts/asm-installer'
+  id: 'setup-long-term-cluster'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - >
+    ./tests/setup_longterm_cluster
+  waitFor:
+  - 'fetch-secrets'
+
   #############
   # FAST TESTS
   #############
@@ -61,7 +72,7 @@ steps:
   - >
     ./tests/run_cli_tests
   waitFor:
-  - 'fetch-secrets'
+  - 'setup-long-term-cluster'
   env:
   - '_CI_ASM_IMAGE_LOCATION=${_IMAGE_LOCATION}'
   - '_CI_ASM_PKG_LOCATION=${_PKG_LOCATION}'
@@ -79,7 +90,7 @@ steps:
   - >
     ./tests/run_print_config_test
   waitFor:
-  - 'fetch-secrets'
+  - 'setup-long-term-cluster'
   env:
   - '_CI_ASM_IMAGE_LOCATION=${_IMAGE_LOCATION}'
   - '_CI_ASM_PKG_LOCATION=${_PKG_LOCATION}'

--- a/scripts/asm-installer/cloudbuild-staging.yaml
+++ b/scripts/asm-installer/cloudbuild-staging.yaml
@@ -51,6 +51,17 @@ steps:
 
 - name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
   dir: 'scripts/asm-installer'
+  id: 'setup-long-term-cluster'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - >
+    ./tests/setup_longterm_cluster
+  waitFor:
+  - 'fetch-secrets'
+
+- name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
+  dir: 'scripts/asm-installer'
   id: 'clean-up-old-clusters'
   entrypoint: '/bin/bash'
   args:
@@ -128,7 +139,7 @@ steps:
   - >
     ./tests/run_cli_tests
   waitFor:
-  - 'fetch-secrets'
+  - 'setup-long-term-cluster'
   env:
   - '_CI_ASM_IMAGE_LOCATION=${_IMAGE_LOCATION}'
   - '_CI_ASM_PKG_LOCATION=${_PKG_LOCATION}'
@@ -146,7 +157,7 @@ steps:
   - >
     ./tests/run_print_config_test
   waitFor:
-  - 'fetch-secrets'
+  - 'setup-long-term-cluster'
   env:
   - '_CI_ASM_IMAGE_LOCATION=${_IMAGE_LOCATION}'
   - '_CI_ASM_PKG_LOCATION=${_PKG_LOCATION}'

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -13,6 +13,15 @@ else
   set -u
 fi
 
+### These are hooks for Cloud Build to be able to use debug/staging images
+### when necessary. Don't set these environment variables unless you're testing
+### in CI/CD.
+_CI_ASM_IMAGE_LOCATION="${_CI_ASM_IMAGE_LOCATION:=}"
+_CI_ASM_PKG_LOCATION="${_CI_ASM_PKG_LOCATION:=}"
+_CI_CLOUDRUN_IMAGE_HUB="${_CI_CLOUDRUN_IMAGE_HUB:=}"
+_CI_CLOUDRUN_IMAGE_TAG="${_CI_CLOUDRUN_IMAGE_TAG:=}"
+_CI_REVISION_PREFIX="${_CI_REVISION_PREFIX:=}"
+
 ### Internal variables ###
 MAJOR="${MAJOR:=1}"
 MINOR="${MINOR:=8}"
@@ -21,18 +30,10 @@ REV="${REV:=5}"
 RELEASE="${MAJOR}.${MINOR}.${POINT}-asm.${REV}"
 RELEASE_LINE="${MAJOR}.${MINOR}."
 PREVIOUS_RELEASE_LINE="${MAJOR}.$(( MINOR - 1 ))."
-REVISION_LABEL="asm-${MAJOR}${MINOR}${POINT}-${REV}"
+REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}-${REV}"
 KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=release-${MAJOR}.${MINOR}-asm}"
 readonly RELEASE; readonly RELEASE_LINE; readonly KPT_BRANCH;
 K8S_MINOR=0
-
-### These are hooks for Cloud Build to be able to use debug/staging images
-### when necessary. Don't set these environment variables unless you're testing
-### in CI/CD.
-_CI_ASM_IMAGE_LOCATION="${_CI_ASM_IMAGE_LOCATION:=}"
-_CI_ASM_PKG_LOCATION="${_CI_ASM_PKG_LOCATION:=}"
-_CI_CLOUDRUN_IMAGE_HUB="${_CI_CLOUDRUN_IMAGE_HUB:=}"
-_CI_CLOUDRUN_IMAGE_TAG="${_CI_CLOUDRUN_IMAGE_TAG:=}"
 
 ### File related constants ###
 ISTIO_FOLDER_NAME="istio-${RELEASE}"; readonly ISTIO_FOLDER_NAME;
@@ -86,6 +87,7 @@ CA_NAME="${CA_NAME:=}"
 
 DRY_RUN="${DRY_RUN:=0}"
 ONLY_VALIDATE="${ONLY_VALIDATE:=0}"
+ONLY_ENABLE="${ONLY_ENABLE:=0}"
 VERBOSE="${VERBOSE:=0}"
 PRINT_HELP=0
 MANAGED="${MANAGED:=0}"
@@ -107,7 +109,11 @@ main() {
   fi
 
   validate_args
-  set_up_local_workspace
+
+  if ! only_enable; then
+    set_up_local_workspace
+  fi
+
   validate_cli_dependencies
 
   if is_sa; then
@@ -196,6 +202,11 @@ main() {
 
   if [[ "${ONLY_VALIDATE}" -eq 1 ]]; then
     info "Successfully validated all requirements to install ASM in this environment."
+    return 0
+  fi
+
+  if only_enable; then
+    info "Successfully performed specified --enable actions."
     return 0
   fi
 
@@ -366,7 +377,11 @@ is_sa() {
 }
 
 should_validate() {
-  if [[ "${PRINT_CONFIG}" -eq 1 ]]; then false; fi
+  if [[ "${PRINT_CONFIG}" -eq 1 ]] || only_enable; then false; fi
+}
+
+only_enable() {
+  if [[ "${ONLY_ENABLE}" -eq 0 ]]; then false; fi
 }
 
 can_modify_at_all() {
@@ -403,6 +418,7 @@ can_modify_gcp_components() {
 
 needs_asm() {
   if [[ "${PRINT_CONFIG}" -eq 0 ]] && ! can_modify_at_all && ! should_validate; then false; fi
+  if only_enable; then false; fi
 }
 
 enable_common_message() {
@@ -451,6 +467,7 @@ FLAGS:
   -v|--verbose
      --dry_run
      --only_validate
+     --only_enable
   -h|--help
 EOF
 }
@@ -558,6 +575,9 @@ FLAGS:
   -v|--verbose                        Print commands before and after execution.
      --dry_run                        Print commands, but don't execute them.
      --only_validate                  Run validation, but don't install.
+     --only_enable                    Perform the specified steps to set up the
+                                      current user/cluster but don't install
+                                      anything.
   -h|--help                           Show this message and exit.
 
 EXAMPLE:
@@ -691,6 +711,10 @@ parse_args() {
         ;;
       --only_validate | --only-validate)
         ONLY_VALIDATE=1
+        shift 1
+        ;;
+      --only_enable | --only-enable)
+        ONLY_ENABLE=1
         shift 1
         ;;
       --ca_cert | --ca-cert)
@@ -835,14 +859,18 @@ ENABLE_GCP_COMPONENTS
 MANAGED
 DISABLE_CANONICAL_SERVICE
 ONLY_VALIDATE
+ONLY_ENABLE
 VERBOSE
 EOF
 
   if [[ "${ENABLE_ALL}" -eq 1 || "${ENABLE_CLUSTER_ROLES}" -eq 1 || \
     "${ENABLE_CLUSTER_LABELS}" -eq 1 || "${ENABLE_GCP_APIS}" -eq 1 || \
-    "${ENABLE_GCP_IAM_ROLES}" -eq 1 || "${ENABLE_GCP_COMPONENTS}" -eq 1 ]] && \
-    [[ "${ONLY_VALIDATE}" -eq 1 ]]; then
+    "${ENABLE_GCP_IAM_ROLES}" -eq 1 || "${ENABLE_GCP_COMPONENTS}" -eq 1 ]]; then
+    if [[ "${ONLY_VALIDATE}" -eq 1 ]]; then
       fatal "The only_validate flag cannot be used with any --enable* flag"
+    fi
+  elif only_enable; then
+    fatal "You must specify at least one --enable* flag with --only_enable"
   fi
 
   if [[ -n "$SERVICE_ACCOUNT" && -z "$KEY_FILE" || -z "$SERVICE_ACCOUNT" && -n "$KEY_FILE" ]]; then

--- a/scripts/asm-installer/tests/setup_longterm_cluster
+++ b/scripts/asm-installer/tests/setup_longterm_cluster
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -CeEu
+set -o pipefail
+
+CLUSTER_NAME="long-term-test-cluster"
+CLUSTER_LOCATION="us-central1-c"
+PROJECT_ID="asm-scriptaro-oss"
+
+RESULT="$(gcloud container clusters list \
+  --project="${PROJECT_ID}" \
+  --filter="name = ${CLUSTER_NAME} and location = ${CLUSTER_LOCATION}" \
+  --format="value(name)" || true)"
+
+if [[ -n "${RESULT}" ]]; then
+  echo "Long term test cluster exists already."
+  exit
+fi
+
+echo "Creating long term test cluster"
+
+gcloud beta container \
+  --project "${PROJECT_ID}" \
+  clusters create "${CLUSTER_NAME}" \
+  \
+  --zone "${CLUSTER_LOCATION}" \
+  --no-enable-basic-auth \
+  --cluster-version "1.17.14-gke.400" \
+  --release-channel "regular" \
+  --machine-type "e2-standard-4" \
+  --image-type "COS" \
+  --disk-type "pd-standard" \
+  --disk-size "100" \
+  --metadata disable-legacy-endpoints=true \
+  --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
+  --num-nodes "4" \
+  --enable-stackdriver-kubernetes \
+  --enable-ip-alias \
+  --network "projects/${PROJECT_ID}/global/networks/default" \
+  --subnetwork "projects/${PROJECT_ID}/regions/us-central1/subnetworks/default" \
+  --default-max-pods-per-node "110" \
+  --enable-autoscaling \
+  --min-nodes "4" \
+  --max-nodes "100" \
+  --no-enable-master-authorized-networks \
+  --addons HorizontalPodAutoscaling,HttpLoadBalancing \
+  --enable-autoupgrade \
+  --enable-autorepair \
+  --max-surge-upgrade 1 \
+  --max-unavailable-upgrade 0 \
+  --workload-pool "${PROJECT_ID}.svc.id.goog" \
+  --enable-shielded-nodes
+
+echo "Performing necessary cluster setup"
+
+../install_asm \
+  -l ${CLUSTER_LOCATION} \
+  -n "${CLUSTER_NAME}" \
+  -p "${PROJECT_ID}" \
+  -m install \
+  --only-enable -e


### PR DESCRIPTION
Add a flag to install_asm that only enables everything without installing anything
Adds script to create a long-term testing cluster if it doesn't already exist, and puts that script
into the cloudbuild pipeline for master and staging
Adds a _CI_REVISION_PREFIX env variable to allow specifying rev name for testing