### PR TITLE
Add support for MCP logging buckets

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -104,6 +104,9 @@ HUB_MEMBERSHIP_ID=""
 # Environment variable used by VM
 USE_VM=0
 
+# Managed Control Plane variables
+LOGS_BUCKET="${LOGS_BUCKET:=asm-control-plane-logs}"
+
 main() {
   init
   parse_args "${@}"
@@ -231,9 +234,11 @@ EOF
   fi
 
   if [[ "${MANAGED}" -eq 1 ]]; then
+    establish_managed_logging_bucket
     start_managed_control_plane
     configure_package
     install_managed_components
+    grant_managed_logging_permissions
     outro
     return 0
   fi
@@ -1975,6 +1980,16 @@ EOF
   fi
 
   outro
+}
+
+establish_managed_logging_bucket() {
+  gcloud beta logging buckets create ${LOGS_BUCKET} --project=${PROJECT_ID} --location=${CLUSTER_LOCATION}
+}
+
+grant_managed_logging_permissions() {
+  gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+    --member=serviceAccount:${MANAGED_SERVICE_ACCOUNT} \
+    --role=roles/logging.bucketWriter
 }
 
 start_managed_control_plane() {

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1982,18 +1982,50 @@ EOF
   outro
 }
 
+pref_len() {
+  local LEN; LEN="${#1}";
+  if ((${#2} > $LEN)); then
+    LEN="${#2}"
+  fi
+
+  for ((i=0; i<$LEN; ++i)); do
+    if [[ "${1:i:1}" != "${2:i:1}" ]]; then
+      echo "${i}"
+      return
+    fi
+  done
+
+  echo "${LEN}"
+}
+
+find_best_region() {
+  REGION="global"
+  BEST=0
+  for location in $(gcloud beta logging locations list --format='value(location_id)'); do
+    SCORE="$(pref_len "${CLUSTER_LOCATION}" "${location}")"
+    if (( $SCORE > $BEST )); then
+      BEST="${SCORE}"
+      REGION="${location}"
+    fi
+  done
+
+  echo ${REGION}
+}
+
+managed_logging_bucket_exists() {
+  BUCKET_LOCATION="$(find_best_region)"
+  BUCKET_COUNT=$(gcloud beta logging buckets list --project="$PROJECT_ID" --location="$BUCKET_LOCATION" --filter="$LOGS_BUCKET" --format=json | jq length)
+
+  if [[ -z "${BUCKET_COUNT}" ]] || [[ "${BUCKET_COUNT}" = '0' ]]; then
+    false
+  fi
+}
+
 establish_managed_logging_bucket() {
-  # The only supported regions are: global, us-central1, us-east1, us-west1, asia-east1, europe-west1.
-  BUCKET_LOCATION="global"
-  case "$CLUSTER_LOCATION" in
-    us-central*    ) BUCKET_LOCATION="us-central1";;
-    us-east*       ) BUCKET_LOCATION="us-east1";;
-    us-west*       ) BUCKET_LOCATION="us-west1";;
-    asia*          ) BUCKET_LOCATION="asia-east1";;
-    europe*        ) BUCKET_LOCATION="europe-west1";;
-    *              ) BUCKET_LOCATION="global";;
-  esac
-  gcloud beta logging buckets create "${LOGS_BUCKET}" --project="${PROJECT_ID}" --location="${BUCKET_LOCATION}"
+  if managed_logging_bucket_exists; then return; fi
+
+  info "creating new logs bucket for managed control plane"
+  gcloud beta logging buckets create "${LOGS_BUCKET}" --project="${PROJECT_ID}" --location="$(find_best_region)"
 }
 
 grant_managed_logging_permissions() {

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1611,7 +1611,7 @@ init_meshconfig_managed() {
   info "Initializing meshconfig managed API..."
   FULL_LOGS_BUCKET_ID="projects/${PROJECT_ID}/locations/$(find_best_region)/buckets/${LOGS_BUCKET}"
   run curl --request POST --fail \
-    --data '{"prepare_istiod": true,"logs_destination":"'${FULL_LOGS_BUCKET_ID}'"}' \
+    --data '{"prepare_istiod": true,"logs_destination":"'"${FULL_LOGS_BUCKET_ID}"'"}' \
     "https://meshconfig.googleapis.com/v1alpha1/projects/${PROJECT_ID}:initialize" \
     --header "X-Server-Timeout: 600" \
     --header "Content-Type: application/json" \

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1983,12 +1983,22 @@ EOF
 }
 
 establish_managed_logging_bucket() {
-  gcloud beta logging buckets create ${LOGS_BUCKET} --project=${PROJECT_ID} --location=${CLUSTER_LOCATION}
+  # The only supported regions are: global, us-central1, us-east1, us-west1, asia-east1, europe-west1.
+  BUCKET_LOCATION="global"
+  case "$CLUSTER_LOCATION" in
+    us-central*    ) BUCKET_LOCATION="us-central1";;
+    us-east*       ) BUCKET_LOCATION="us-east1";;
+    us-west*       ) BUCKET_LOCATION="us-west1";;
+    asia*          ) BUCKET_LOCATION="asia-east1";;
+    europe*        ) BUCKET_LOCATION="europe-west1";;
+    *              ) BUCKET_LOCATION="global";;
+  esac
+  gcloud beta logging buckets create "${LOGS_BUCKET}" --project="${PROJECT_ID}" --location="${BUCKET_LOCATION}"
 }
 
 grant_managed_logging_permissions() {
-  gcloud projects add-iam-policy-binding ${PROJECT_ID} \
-    --member=serviceAccount:${MANAGED_SERVICE_ACCOUNT} \
+  gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+    --member=serviceAccount:"${MANAGED_SERVICE_ACCOUNT}" \
     --role=roles/logging.bucketWriter
 }
 

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -106,6 +106,7 @@ USE_VM=0
 
 # Managed Control Plane variables
 LOGS_BUCKET="${LOGS_BUCKET:=asm-control-plane-logs}"
+LOGS_WRITER_IDENTITY=""
 
 main() {
   init
@@ -162,8 +163,11 @@ main() {
     if can_modify_gcp_iam_roles; then
       bind_user_to_iam_policy "roles/meshconfig.admin" "$(local_iam_user)"
     fi
+    establish_managed_logging_bucket
     MANAGED_SERVICE_JSON="$(init_meshconfig_managed)"
+    # TODO: prepend MSA with "serviceAccount:"
     MANAGED_SERVICE_ACCOUNT="$(echo "${MANAGED_SERVICE_JSON}" | jq -r .serviceAccount)"
+    LOGS_WRITER_IDENTITY="$(echo "${MANAGED_SERVICE_JSON}" | jq -r .logsWriterIdentity)"
     if [[ -z "${MANAGED_SERVICE_JSON}" || "${MANAGED_SERVICE_ACCOUNT}" == "null" ]]; then
       fatal "Couldn't initialize meshconfig, do you have the required permission resourcemanager.projects.setIamPolicy?"
     fi
@@ -234,7 +238,6 @@ EOF
   fi
 
   if [[ "${MANAGED}" -eq 1 ]]; then
-    establish_managed_logging_bucket
     start_managed_control_plane
     configure_package
     install_managed_components
@@ -1516,6 +1519,7 @@ roles/iam.serviceAccountAdmin
 roles/iam.serviceAccountKeyAdmin
 roles/gkehub.admin
 roles/privateca.admin
+roles/logging.buckets.create
 EOF
 }
 
@@ -1605,8 +1609,9 @@ EOF
 
 init_meshconfig_managed() {
   info "Initializing meshconfig managed API..."
+  FULL_LOGS_BUCKET_ID="projects/${PROJECT_ID}/locations/$(find_best_region)/buckets/${LOGS_BUCKET}"
   run curl --request POST --fail \
-    --data '{"prepare_istiod": true}' \
+    --data '{"prepare_istiod": true,"logs_destination":"'${FULL_LOGS_BUCKET_ID}'"}' \
     "https://meshconfig.googleapis.com/v1alpha1/projects/${PROJECT_ID}:initialize" \
     --header "X-Server-Timeout: 600" \
     --header "Content-Type: application/json" \
@@ -1984,11 +1989,11 @@ EOF
 
 pref_len() {
   local LEN; LEN="${#1}";
-  if ((${#2} > $LEN)); then
+  if ((${#2} > LEN)); then
     LEN="${#2}"
   fi
 
-  for ((i=0; i<$LEN; ++i)); do
+  for ((i=0; i<LEN; ++i)); do
     if [[ "${1:i:1}" != "${2:i:1}" ]]; then
       echo "${i}"
       return
@@ -2003,18 +2008,19 @@ find_best_region() {
   BEST=0
   for location in $(gcloud beta logging locations list --format='value(location_id)'); do
     SCORE="$(pref_len "${CLUSTER_LOCATION}" "${location}")"
-    if (( $SCORE > $BEST )); then
+    if (( SCORE > BEST )); then
       BEST="${SCORE}"
       REGION="${location}"
     fi
   done
 
-  echo ${REGION}
+  echo "${REGION}"
 }
 
 managed_logging_bucket_exists() {
   BUCKET_LOCATION="$(find_best_region)"
-  BUCKET_COUNT=$(gcloud beta logging buckets list --project="$PROJECT_ID" --location="$BUCKET_LOCATION" --filter="$LOGS_BUCKET" --format=json | jq length)
+  FULL_LOGS_BUCKET_ID="projects/${PROJECT_ID}/locations/$(find_best_region)/buckets/${LOGS_BUCKET}"
+  BUCKET_COUNT=$(gcloud beta logging buckets list --project="$PROJECT_ID" --location="$BUCKET_LOCATION" --filter="name:${FULL_LOGS_BUCKET_ID}" --format=json | jq length)
 
   if [[ -z "${BUCKET_COUNT}" ]] || [[ "${BUCKET_COUNT}" = '0' ]]; then
     false
@@ -2024,13 +2030,14 @@ managed_logging_bucket_exists() {
 establish_managed_logging_bucket() {
   if managed_logging_bucket_exists; then return; fi
 
-  info "creating new logs bucket for managed control plane"
-  gcloud beta logging buckets create "${LOGS_BUCKET}" --project="${PROJECT_ID}" --location="$(find_best_region)"
+  info "creating new logs bucket for managed control plane..."
+  run gcloud beta logging buckets create "${LOGS_BUCKET}" --project="${PROJECT_ID}" --location="$(find_best_region)"
 }
 
 grant_managed_logging_permissions() {
-  gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-    --member=serviceAccount:"${MANAGED_SERVICE_ACCOUNT}" \
+  info "granting permissions to write to the logs bucket..."
+  run gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+    --member=serviceAccount:"${LOGS_WRITER_IDENTITY}" \
     --role=roles/logging.bucketWriter
 }
 


### PR DESCRIPTION
This PR adds support for creating logs buckets in the consumer project for receiving control plane logs in managed scenarios.

A few notes:
- The logs bucket is created in the same location as the target cluster
- A default name of `asm-control-plane-logs` is used for the bucket. If customization is needed, coordination with the managed service will be needed.

/hold 

This update has been validated in standalone installs, but the managed control plane has not yet been updated to support sending logs to the bucket, so this should not be merged until validated e2e.