### PR TITLE
Revision based istio-ingressgateway

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -317,3 +317,11 @@ openAPI:
           name: anthos.servicemesh.external_ca.ca_name
           value: ""
           isSet: true
+    io.k8s.cli.substitutions.istio-ingressgateway-deploy-name:
+      x-k8s-cli:
+        substitution:
+          name: istio-ingressgateway-deploy-name
+          pattern: istio-ingressgateway-ASM_REV
+          values:
+          - marker: ASM_REV
+            ref: '#/definitions/io.k8s.cli.setters.anthos.servicemesh.rev'

--- a/asm/istio/options/revisioned-istio-ingressgateway.yaml
+++ b/asm/istio/options/revisioned-istio-ingressgateway.yaml
@@ -1,0 +1,37 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    ingressGateways:
+    # Disable istio-ingressgateway to avoid downtime from in-place upgrade
+    - name: istio-ingressgateway
+      enabled: false
+    # Workaround to use revision based deployments for istio-ingressgateway
+    - name: istio-ingressgateway-ASM_REV # {"$ref":"#/definitions/io.k8s.cli.substitutions.istio-ingressgateway-deploy-name"}
+      enabled: true
+      k8s:
+        hpaSpec:
+          maxReplicas: 5
+          minReplicas: 2
+        overlays:
+        # Overlay service to still use istio-ingressgateway
+        - apiVersion: extensions/v1beta1
+          kind: Service
+          name: istio-ingressgateway-ASM_REV # {"$ref":"#/definitions/io.k8s.cli.substitutions.istio-ingressgateway-deploy-name"}
+          patches:
+          - path: metadata.name
+            value: istio-ingressgateway

--- a/asm/istio/options/revisioned-istio-ingressgateway.yaml
+++ b/asm/istio/options/revisioned-istio-ingressgateway.yaml
@@ -27,8 +27,8 @@ spec:
         hpaSpec:
           maxReplicas: 5
           minReplicas: 2
+        # Rename the service to still use istio-ingressgateway
         overlays:
-        # Overlay service to still use istio-ingressgateway
         - apiVersion: extensions/v1beta1
           kind: Service
           name: istio-ingressgateway-ASM_REV # {"$ref":"#/definitions/io.k8s.cli.substitutions.istio-ingressgateway-deploy-name"}

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -2020,7 +2020,7 @@ EOF
 
   info "Installing ASM control plane..."
   # shellcheck disable=SC2086
-  retry 5 run "$(istioctl_path)" install --skip-confirmation $PARAMS
+  retry 5 run "$(istioctl_path)" install $PARAMS
 
   # Prevent the stderr buffer from ^ messing up the terminal output below
   sleep 1


### PR DESCRIPTION
I tested with istioctl and kubectl on ingressgateways for a while with different combinations of config structures, and think this is the optimal approach for revision based gateways. Comparing to the original proposal:

- We don't separate the gateways from their original yamls because that introduces one more jump/mapping from an install option to its gateways.
- We still use a single istioctl install command to install a new revision of ingressgateway, istiod, and other resources. But now each revision ingressgateway will get a separate deployment, naming  istio-ingressgateway-ASM_REV.
- We will put the command of switching ingressgateway revisions into our upgrade guide, and let user decide when to change revision to be used. And in the rollback process, user will get a *symmetric* command to change it back.
- We will recommend users to use the new revision of ingressgateway before re-inject workloads. After all workloads get re-injected, there won't be any long lived connections through the old ingressgateway, so it will be safe to cleanup all old revision resources including ingressgateway deployment without disrupting traffic. 

```
kubectl patch service -n istio-system istio-ingressgateway --type='json' -p='[{"op": "replace", "path": "/spec/selector/service.istio.io~1canonical-revision", "value": "<ASM_REV>"}]'
```

If this looks good, I will create followup CRs (or notify the owners) to apply this method to other gateways in options.