### PR TITLE
Check existence of membership object before getting it (#392)

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1692,6 +1692,12 @@ get_cluster_labels() {
 }
 
 is_cluster_registered() {
+
+  if ! kubectl api-resources --api-group=hub.gke.io | grep -q memberships; then
+    false
+    return
+  fi
+
   local WANT
   WANT="//container.googleapis.com/projects/${PROJECT_ID}/locations/${CLUSTER_LOCATION}/clusters/${CLUSTER_NAME}"
   local LIST; LIST="$(gcloud container hub memberships list --project "${PROJECT_ID}" --format=json | grep "${WANT}")"


### PR DESCRIPTION
This will break MCP private preview customers that aren't registered to Hub already if they hit a code path that checks for membership.