### PR TITLE
Add CLOUDRUN_ADDR for managed control plane (#393)

### DIFF
--- a/asm/istio/options/managed-control-plane.yaml
+++ b/asm/istio/options/managed-control-plane.yaml
@@ -43,6 +43,7 @@ spec:
         OUTPUT_CERTS: "/etc/istio/proxy"
         XDS_TOKEN_TYPE: "Istio"
         XDS_HEADER_Cloud-Run-Enable-H2: "y"
+        ISTIO_META_CLOUDRUN_ADDR: "ISTIO_CLOUDRUN_ADDR" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.managed-controlplane.cloudrun-addr"}
   values:
     gateways:
       istio-ingressgateway:

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -2066,9 +2066,12 @@ install_managed_components() {
   local URL
   URL="$(kubectl get mutatingwebhookconfiguration istiod-asm-managed -ojson | jq .webhooks[0].clientConfig.url -r)"
   # shellcheck disable=SC2001
-  URL="$(echo "${URL}" | sed 's/inject.*$/validate/g')"
+  VALIDATION_URL="$(echo "${URL}" | sed 's/inject.*$/validate/g')"
+  # shellcheck disable=SC2001
+  CLOUDRUN_ADDR=$(echo "${URL}" | cut -d'/' -f3)
 
-  run kpt cfg set asm anthos.servicemesh.controlplane.validation-url "${URL}"
+  run kpt cfg set asm anthos.servicemesh.controlplane.validation-url "${VALIDATION_URL}"
+  run kpt cfg set asm anthos.servicemesh.managed-controlplane.cloudrun-addr "${CLOUDRUN_ADDR}"
 
   info "Configuring base installation for managed control plane..."
 


### PR DESCRIPTION
For Gateway, a new env (ISTIO_META_CLOUDRUN_ADDR) is needed.
The value of this env is obtained from mutatingwebhook after
MCP installation.