### PR TITLE
Skip populate_environ_info for managed control plane

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1924,7 +1924,9 @@ configure_package() {
   info "Configuring kpt package..."
 
   populate_cluster_values
-  populate_environ_info
+  if ! is_managed; then
+    populate_environ_info
+  fi
   run kpt cfg set asm gcloud.container.cluster "${CLUSTER_NAME}"
   run kpt cfg set asm gcloud.core.project "${PROJECT_ID}"
   run kpt cfg set asm gcloud.project.environProjectNumber "${PROJECT_NUMBER}"


### PR DESCRIPTION
During managed control plane installation,
```
install_asm: Verifying connectivity (20s)...
install_asm: kubeconfig set to istio-ruigu/us-central1-a/cr-istiod-testing...
error: the server doesn't have a resource type "memberships"
```