### PR TITLE
Overwrite final config when reusing output directory

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -2041,10 +2041,10 @@ EOF
 
   local RAW_YAML; RAW_YAML="${REVISION_LABEL}-manifest-raw.yaml"
   local EXPANDED_YAML; EXPANDED_YAML="${REVISION_LABEL}-manifest-expanded.yaml"
-  print_config > "${RAW_YAML}"
+  print_config >| "${RAW_YAML}"
   run "$(istioctl_path)" manifest generate \
     <"${RAW_YAML}" \
-    >"${EXPANDED_YAML}"
+    >|"${EXPANDED_YAML}"
 
   if [[ "$DISABLE_CANONICAL_SERVICE" -eq 0 ]]; then
     install_canonical_controller


### PR DESCRIPTION
Re-using the same output directory multiple times will cause an error, since we told bash at the very beginning not to let us overwrite files by default. This explicitly lets us do that after a successful installation.