### PR TITLE
Work around istioctl bug with multi component yaml files

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1116,7 +1116,9 @@ handle_multi_yaml_bug() {
   done <<EOF
 ${CUSTOM_OVERLAY}
 EOF
-  CUSTOM_OVERLAY="${CSPLIT_OUTPUT:1:${#CSPLIT_OUTPUT}},"
+  if [[ -n "${CSPLIT_OUTPUT}" ]]; then
+    CUSTOM_OVERLAY="${CSPLIT_OUTPUT:1:${#CSPLIT_OUTPUT}},"
+  fi
 }
 
 validate_cli_dependencies() {

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1094,7 +1094,29 @@ EOF
   done <<EOF
 ${OPTIONAL_OVERLAY}
 EOF
+  handle_multi_yaml_bug
 unset OPTIONAL_OVERLAY; readonly CUSTOM_OVERLAY
+}
+
+# This is a workaround for https://github.com/istio/istio/issues/30632
+# which doesn't handle files with multiple operator specs correctly.
+# This will split all of the files based off of the yaml document separator.
+handle_multi_yaml_bug() {
+  local CSPLIT_OUTPUT; CSPLIT_OUTPUT="";
+  local BASE_NAME
+  while read -d ',' -r yaml_file; do
+    BASE_NAME="$(basename "${yaml_file}")"
+    if [[ "$(csplit -z -f "overlay-${BASE_NAME}" -z "${yaml_file}" '/^---$/' '{*}' | wc -l)" -eq 1 ]]; then
+      CSPLIT_OUTPUT="${CSPLIT_OUTPUT},${yaml_file}"
+    else
+      for split_file in overlay-"${BASE_NAME}"*; do
+        CSPLIT_OUTPUT="${CSPLIT_OUTPUT},$(apath -f "${split_file}")"
+      done
+    fi
+  done <<EOF
+${CUSTOM_OVERLAY}
+EOF
+  CUSTOM_OVERLAY="${CSPLIT_OUTPUT:1:${#CSPLIT_OUTPUT}},"
 }
 
 validate_cli_dependencies() {

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1140,6 +1140,7 @@ kubectl
 sed
 tr
 head
+csplit
 EOF
 
   if [[ "${CUSTOM_CA}" -eq 1 ]]; then

--- a/scripts/asm-installer/tests/run_print_config_test
+++ b/scripts/asm-installer/tests/run_print_config_test
@@ -11,23 +11,58 @@ SDIR="$(dirname "${SPATH}")"; export SDIR;
 cd "${SDIR}"
 
 main() {
-  echo '../install_asm \
-    -l us-central1-c \
-    -n long-term-test-cluster \
-    -p asm-scriptaro-oss \
-    --print-config \
-    --option egressgateways \
-    -m install \
-    | grep egressGateways: -A 1 | tail -n 1 | grep enabled: true -q'
+  local RETVAL; RETVAL=0;
+  local CUSTOM_OVERLAY; CUSTOM_OVERLAY="$(mktemp)"
 
-  RETVAL="$(../install_asm \
+  trap 'rm "${CUSTOM_OVERLAY}"' ERR EXIT
+
+  cat <<EOF >|"${CUSTOM_OVERLAY}"
+---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    base:
+      enabled: false
+---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    base:
+      enabled: true
+EOF
+
+  echo "../install_asm \
     -l us-central1-c \
     -n long-term-test-cluster \
     -p asm-scriptaro-oss \
     --print-config \
     --option egressgateways \
-    -m install \
-    | grep egressGateways: -A 1 | tail -n 1 | grep 'enabled: true' -q)"
+    --custom_overlay ${CUSTOM_OVERLAY} \
+    -m install"
+
+  CONFIG="$(../install_asm \
+    -l us-central1-c \
+    -n long-term-test-cluster \
+    -p asm-scriptaro-oss \
+    --print-config \
+    --option egressgateways \
+    --custom_overlay ${CUSTOM_OVERLAY} \
+    -m install)"
+
+  if ! echo "${CONFIG}" | grep egressGateways: -A 1 | tail -n 1 | grep 'enabled: true' -q; then
+    echo "Print config doesn't pick up --option files!"
+    RETVAL=1
+  fi
+
+  if ! echo "${CONFIG}" | grep base: -A 1 | grep 'enabled: true' -q; then
+    echo "Not handling multi-component yaml properly!"
+    RETVAL=1
+  fi
+
+  trap - ERR EXIT
+  rm "${CUSTOM_OVERLAY}"
 
   if [[ "${RETVAL}" -ne 0 ]]; then
     echo FAILED


### PR DESCRIPTION
If `csplit` generates more than one file when splitting on the yaml document separator, then remove the yaml file from the list of files to pass to `istioctl` and instead add the split yaml files. Verified that the new test fails before adding the fix.