### PR TITLE
Conditionally require roles

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -27,6 +27,7 @@ _CI_NO_REVISION="${_CI_NO_REVISION:=0}"
 _CI_ISTIOCTL_REL_PATH="${_CI_ISTIOCTL_REL_PATH:=}"
 _CI_TRUSTED_GCP_PROJECTS="${_CI_TRUSTED_GCP_PROJECTS:=}"
 _CI_ENVIRON_PROJECT_NUMBER="${_CI_ENVIRON_PROJECT_NUMBER:=}"
+_CI_I_AM_A_TEST_ROBOT="${_CI_I_AM_A_TEST_ROBOT:=0}"
 
 ### Internal variables ###
 MAJOR="${MAJOR:=1}"
@@ -1574,20 +1575,34 @@ istioctl_path() {
 }
 
 required_iam_roles() {
-  # meshconfig.admin - required for init, stackdriver, UI elements, etc.
-  # servicemanagement.admin/serviceusage.serviceUsageAdmin - enables APIs
-  cat <<EOF
-roles/servicemanagement.admin
-roles/serviceusage.serviceUsageAdmin
-roles/meshconfig.admin
-roles/compute.admin
-roles/container.admin
-roles/resourcemanager.projectIamAdmin
-roles/iam.serviceAccountAdmin
-roles/iam.serviceAccountKeyAdmin
-roles/gkehub.admin
-roles/privateca.admin
-EOF
+  if can_modify_gcp_components || \
+     can_modify_cluster_labels || \
+     can_modify_cluster_roles; then
+    echo roles/container.admin
+  fi
+  if can_modify_gcp_components; then
+    echo roles/meshconfig.admin
+  fi
+  if can_modify_gcp_apis; then
+    echo roles/servicemanagement.admin
+    echo roles/serviceusage.serviceUsageAdmin
+  fi
+  if can_modify_gcp_iam_roles; then
+    echo roles/resourcemanager.projectIamAdmin
+  fi
+  if is_sa; then
+    echo roles/iam.serviceAccountAdmin
+  fi
+  if can_register_cluster; then
+    echo roles/gkehub.admin
+  fi
+  if [[ "${CA}" = "gcp_cas" ]]; then
+    echo roles/privateca.admin
+  fi
+  if [[ "${_CI_I_AM_A_TEST_ROBOT}" -eq 1 ]]; then
+    echo roles/compute.admin
+    echo roles/iam.serviceAccountKeyAdmin
+  fi
 }
 
 # [START required_apis]

--- a/scripts/asm-installer/tests/setup_longterm_cluster
+++ b/scripts/asm-installer/tests/setup_longterm_cluster
@@ -69,7 +69,8 @@ fi
 
 echo "Performing necessary cluster setup"
 
-../install_asm \
+_CI_I_AM_A_TEST_ROBOT=1 \
+  ../install_asm \
   -l ${LT_CLUSTER_LOCATION} \
   -n "${LT_CLUSTER_NAME}" \
   -p "${LT_PROJECT_ID}" \


### PR DESCRIPTION
Pare down the requires roles depending on what dependencies you need to touch. Also add a flag for test bots who need extra permissions to take actions that are in the e2e tests/setup but not normal script execution.