### PR TITLE
Enable specifying alpha builds for testing

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -29,31 +29,25 @@ _CI_TRUSTED_GCP_PROJECTS="${_CI_TRUSTED_GCP_PROJECTS:=}"
 _CI_ENVIRON_PROJECT_NUMBER="${_CI_ENVIRON_PROJECT_NUMBER:=}"
 
 ### Internal variables ###
-MAJOR="${MAJOR:=1}"
-MINOR="${MINOR:=8}"
-POINT="${POINT:=2}"
-REV="${REV:=2}"
-RELEASE="${MAJOR}.${MINOR}.${POINT}-asm.${REV}"
-RELEASE_LINE="${MAJOR}.${MINOR}."
-PREVIOUS_RELEASE_LINE="${MAJOR}.$(( MINOR - 1 ))."
-REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}-${REV}"
-KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=release-${MAJOR}.${MINOR}-asm}"
-readonly RELEASE; readonly RELEASE_LINE; readonly KPT_BRANCH;
+MAJOR="${MAJOR:=1}"; readonly MAJOR;
+MINOR="${MINOR:=8}"; readonly MINOR;
+POINT="${POINT:=2}"; readonly POINT;
+REV="${REV:=2}"; readonly REV;
 K8S_MINOR=0
 
 ### File related constants ###
-ISTIO_FOLDER_NAME="istio-${RELEASE}"; readonly ISTIO_FOLDER_NAME;
-ISTIOCTL_REL_PATH="${ISTIO_FOLDER_NAME}/bin/istioctl"; readonly ISTIOCTL_REL_PATH;
-BASE_REL_PATH="${ISTIO_FOLDER_NAME}/manifests/charts/base/files/gen-istio-cluster.yaml"; readonly BASE_REL_PATH;
-PACKAGE_DIRECTORY="asm/istio"; readonly PACKAGE_DIRECTORY;
-VALIDATION_FIX_SERVICE="${PACKAGE_DIRECTORY}/istiod-service.yaml"; readonly VALIDATION_FIX_SERVICE;
-OPTIONS_DIRECTORY="${PACKAGE_DIRECTORY}/options"; readonly OPTIONS_DIRECTORY;
-OPERATOR_MANIFEST="${PACKAGE_DIRECTORY}/istio-operator.yaml"; readonly OPERATOR_MANIFEST;
-BETA_CRD_MANIFEST="${OPTIONS_DIRECTORY}/v1beta1-crds.yaml"; readonly BETA_CRD_MANIFEST;
-MANAGED_MANIFEST="${OPTIONS_DIRECTORY}/managed-control-plane.yaml"; readonly MANAGED_MANIFEST;
-MANAGED_WEBHOOKS="${OPTIONS_DIRECTORY}/managed-control-plane-webhooks.yaml"; readonly MANAGED_WEBHOOKS;
-EXPOSE_ISTIOD_SERVICE="${PACKAGE_DIRECTORY}/expansion/expose-istiod.yaml"; readonly EXPOSE_ISTIOD_SERVICE;
-CANONICAL_CONTROLLER_MANIFEST="asm/canonical-service/controller.yaml"; readonly CANONICAL_CONTROLLER_MANIFEST;
+ISTIO_FOLDER_NAME=""
+ISTIOCTL_REL_PATH=""
+BASE_REL_PATH=""
+PACKAGE_DIRECTORY=""
+VALIDATION_FIX_SERVICE=""
+OPTIONS_DIRECTORY=""
+OPERATOR_MANIFEST=""
+BETA_CRD_MANIFEST=""
+MANAGED_MANIFEST=""
+MANAGED_WEBHOOKS=""
+EXPOSE_ISTIOD_SERVICE=""
+CANONICAL_CONTROLLER_MANIFEST=""
 
 SCRIPT_NAME="${0##*/}"
 
@@ -68,6 +62,11 @@ AKUBECTL=""
 AKPT=""
 AGCLOUD=""
 ABS_OVERLAYS=""
+RELEASE=""
+REVISION_LABEL=""
+RELEASE_LINE=""
+PREVIOUS_RELEASE_LINE=""
+KPT_BRANCH=""
 
 ### Option variables ###
 PROJECT_ID="${PROJECT_ID:=}"
@@ -277,6 +276,32 @@ init() {
     Darwin) APATH="stat";;
     *);;
   esac
+
+  if [[ "${POINT}" == "alpha" ]]; then
+    RELEASE="${MAJOR}.${MINOR}-alpha.${REV}"
+    REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}"
+    KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=master}"
+  else
+    RELEASE="${MAJOR}.${MINOR}.${POINT}-asm.${REV}"
+    REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}-${REV}"
+    KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=release-${MAJOR}.${MINOR}-asm}"
+  fi
+  RELEASE_LINE="${MAJOR}.${MINOR}."
+  PREVIOUS_RELEASE_LINE="${MAJOR}.$(( MINOR - 1 ))."
+  readonly RELEASE; readonly RELEASE_LINE; readonly PREVIOUS_RELEASE_LINE; readonly KPT_BRANCH;
+
+  ISTIO_FOLDER_NAME="istio-${RELEASE}"; readonly ISTIO_FOLDER_NAME;
+  ISTIOCTL_REL_PATH="${ISTIO_FOLDER_NAME}/bin/istioctl"; readonly ISTIOCTL_REL_PATH;
+  BASE_REL_PATH="${ISTIO_FOLDER_NAME}/manifests/charts/base/files/gen-istio-cluster.yaml"; readonly BASE_REL_PATH;
+  PACKAGE_DIRECTORY="asm/istio"; readonly PACKAGE_DIRECTORY;
+  VALIDATION_FIX_SERVICE="${PACKAGE_DIRECTORY}/istiod-service.yaml"; readonly VALIDATION_FIX_SERVICE;
+  OPTIONS_DIRECTORY="${PACKAGE_DIRECTORY}/options"; readonly OPTIONS_DIRECTORY;
+  OPERATOR_MANIFEST="${PACKAGE_DIRECTORY}/istio-operator.yaml"; readonly OPERATOR_MANIFEST;
+  BETA_CRD_MANIFEST="${OPTIONS_DIRECTORY}/v1beta1-crds.yaml"; readonly BETA_CRD_MANIFEST;
+  MANAGED_MANIFEST="${OPTIONS_DIRECTORY}/managed-control-plane.yaml"; readonly MANAGED_MANIFEST;
+  MANAGED_WEBHOOKS="${OPTIONS_DIRECTORY}/managed-control-plane-webhooks.yaml"; readonly MANAGED_WEBHOOKS;
+  EXPOSE_ISTIOD_SERVICE="${PACKAGE_DIRECTORY}/expansion/expose-istiod.yaml"; readonly EXPOSE_ISTIOD_SERVICE;
+  CANONICAL_CONTROLLER_MANIFEST="asm/canonical-service/controller.yaml"; readonly CANONICAL_CONTROLLER_MANIFEST;
 
   AKUBECTL="$(which kubectl || true)"
   AGCLOUD="$(which gcloud || true)"

--- a/scripts/asm-installer/tests/common.sh
+++ b/scripts/asm-installer/tests/common.sh
@@ -4,6 +4,7 @@ LT_PROJECT_ID="asm-scriptaro-oss"
 LT_NAMESPACE=""
 OUTPUT_DIR=""
 
+_EXTRA_FLAGS="${_EXTRA_FLAGS:=}"; export _EXTRA_FLAGS;
 BUILD_ID="${BUILD_ID:=}"; export BUILD_ID;
 PROJECT_ID="${PROJECT_ID:=}"; export PROJECT_ID;
 CLUSTER_LOCATION="${CLUSTER_LOCATION:=us-central1-c}"; export CLUSTER_LOCATION;
@@ -618,7 +619,7 @@ run_basic_test() {
     -m "${MODE}" \
     -c "${CA}" -v \
     --output-dir "${OUTPUT_DIR}" \
-    ${EXTRA_FLAGS} 2>&1 | tee "${LT_NAMESPACE}" &
+    ${EXTRA_FLAGS} ${_EXTRA_FLAGS} 2>&1 | tee "${LT_NAMESPACE}" &
 
   LABEL="$(grep -o -m 1 'istio.io/rev=\S*' "${LT_NAMESPACE}")"
   REV="$(echo "${LABEL}" | cut -f 2 -d =)"


### PR DESCRIPTION
Mostly moving a bunch of constant declarations to init. Also added a QOL improvement for local testing (so it's easier to specify `--enable-cluster-labels` when testing new versions)