### PR TITLE
Remove VM suite from master pre-submit tests

### DIFF
--- a/scripts/asm-installer/cloudbuild-master.yaml
+++ b/scripts/asm-installer/cloudbuild-master.yaml
@@ -130,42 +130,6 @@ steps:
 
 - name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
   dir: 'scripts/asm-installer'
-  id: 'run-basic-suite-vm'
-  entrypoint: '/bin/bash'
-  args:
-  - '-c'
-  - >
-    ./tests/run_basic_suite_vm
-    --PROJECT_ID "${PROJECT_ID}"
-    --BUILD_ID "${BUILD_ID}"
-  env:
-  - 'SERVICE_ACCOUNT=${_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com'
-  - 'KEY_FILE=${_KEY_FILE}'
-  - '_CI_ASM_IMAGE_LOCATION=${_IMAGE_LOCATION}'
-  - '_CI_ASM_PKG_LOCATION=${_PKG_LOCATION}'
-  - '_CI_ASM_KPT_BRANCH=${_ASM_PKG_BRANCH}'
-  timeout: 600s
-
-- name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
-  dir: 'scripts/asm-installer'
-  id: 'run_basic_instance_template_creation'
-  entrypoint: '/bin/bash'
-  args:
-  - '-c'
-  - >
-    ./tests/run_basic_instance_template_creation
-    --PROJECT_ID "${PROJECT_ID}"
-    --BUILD_ID "${BUILD_ID}"
-  env:
-  - 'SERVICE_ACCOUNT=${_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com'
-  - 'KEY_FILE=${_KEY_FILE}'
-  - '_CI_ASM_IMAGE_LOCATION=${_IMAGE_LOCATION}'
-  - '_CI_ASM_PKG_LOCATION=${_PKG_LOCATION}'
-  - '_CI_ASM_KPT_BRANCH=${_ASM_PKG_BRANCH}'
-  timeout: 600s
-
-- name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
-  dir: 'scripts/asm-installer'
   id: 'run-install-custom-cert-suite'
   entrypoint: '/bin/bash'
   args:


### PR DESCRIPTION
There seems to be some sporadic issues that only affect Hub,
since that's not a strong dependency yet we should disable it until
we can figure out what the issue is.