### PR TITLE
Fix option flags being ignored issue when reinstalling on an existing folder

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -146,7 +146,10 @@ main() {
 
   if needs_asm && ! necessary_files_exist; then
     download_asm
-    validate_kpt_files
+  fi
+
+  if needs_asm ; then
+    organize_kpt_files
   fi
 
   if should_validate && ! is_managed; then
@@ -1140,13 +1143,13 @@ validate_dependencies() {
   fi
 }
 
-validate_kpt_files () {
+organize_kpt_files () {
   local ABS_YAML
   while read -d ',' -r yaml_file; do
     ABS_YAML="${OPTIONS_DIRECTORY}/${yaml_file}.yaml"
     if [[ ! -f "${ABS_YAML}" ]]; then
     { read -r -d '' MSG; fatal "${MSG}"; } <<EOF || true
-Couldn't find remote yaml file ${yaml_file}.
+Couldn't find yaml file ${yaml_file}.
 See directory $(apath -f "${OPTIONS_DIRECTORY}") for available options.
 EOF
     fi

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -148,7 +148,7 @@ main() {
     download_asm
   fi
 
-  if needs_asm ; then
+  if needs_asm; then
     organize_kpt_files
   fi
 
@@ -1143,7 +1143,7 @@ validate_dependencies() {
   fi
 }
 
-organize_kpt_files () {
+organize_kpt_files() {
   local ABS_YAML
   while read -d ',' -r yaml_file; do
     ABS_YAML="${OPTIONS_DIRECTORY}/${yaml_file}.yaml"


### PR DESCRIPTION
When reinstalling with an existing folder, options are not converted into yamls in CUSTOM_OVERLAY. This PR should fix it.