### PR TITLE
Allow revisioned istiod to be exposed for discovery

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -120,6 +120,24 @@ openAPI:
           name: anthos.servicemesh.rev
           value: ASM_REV
           isSet: true
+    io.k8s.cli.setters.anthos.servicemesh.istiodHost:
+      x-k8s-cli:
+        setter:
+          name: anthos.servicemesh.istiodHost
+          value: istiod.istio-system.svc.cluster.local
+          isSet: true
+    io.k8s.cli.setters.anthos.servicemesh.istiod-vs-name:
+      x-k8s-cli:
+        setter:
+          name: anthos.servicemesh.istiod-vs-name
+          value: istiod-vs
+          isSet: true
+    io.k8s.cli.setters.anthos.servicemesh.istiod-dr-name:
+      x-k8s-cli:
+        setter:
+          name: anthos.servicemesh.istiod-dr-name
+          value: istiod-dr
+          isSet: true
     io.k8s.cli.setters.anthos.servicemesh.canonicalServiceHub:
       x-k8s-cli:
         setter:

--- a/asm/istio/expansion/expose-istiod.yaml
+++ b/asm/istio/expansion/expose-istiod.yaml
@@ -23,11 +23,11 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: istiod-vs
+  name: istiod-vs # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.istiod-vs-name"}
   namespace: istio-system
 spec:
   hosts:
-  - istiod.istio-system.svc.cluster.local
+  - istiod.istio-system.svc.cluster.local # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.istiodHost"}
   gateways:
   - istiod-gateway
   tcp:
@@ -35,24 +35,24 @@ spec:
     - port: 15012
     route:
     - destination:
-        host: istiod.istio-system.svc.cluster.local
+        host: istiod.istio-system.svc.cluster.local # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.istiodHost"}
         port:
           number: 15012
   - match:
     - port: 15017
     route:
     - destination:
-        host: istiod.istio-system.svc.cluster.local
+        host: istiod.istio-system.svc.cluster.local # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.istiodHost"}
         port:
           number: 443
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: istiod-dr
+  name: istiod-dr # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.istiod-dr-name"}
   namespace: istio-system
 spec:
-  host: istiod.istio-system.svc.cluster.local
+  host: istiod.istio-system.svc.cluster.local # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.istiodHost"}
   trafficPolicy:
     portLevelSettings:
     - port:


### PR DESCRIPTION
Re-using the existing file so that multiproject multicluster setup can still use the same file.

Manually asking @nmittler for review. Nathan, can you also take a look at the change?