### PR TITLE
[VM Script] Add revisioned Istiod support

### DIFF
--- a/asm/vm/asm_vm
+++ b/asm/vm/asm_vm
@@ -991,6 +991,7 @@ gen_gce_service_proxy() {
     --arg project_number "${PROJECT_NUMBER}" \
     --arg workload_namespace "${WORKLOAD_NAMESPACE}" \
     --arg service_account "${WORKLOAD_SERVICE_ACCOUNT}" \
+    --arg asm_revision "${WORKLOAD_ASM_REVISION}"\
     --arg credential_identity_provider "${CREDENTIAL_IDENTITY_PROVIDER}" \
     --arg network "${NETWORK}" \
     --arg asm_meta_version "${ASM_META_VERSION}" '{
@@ -1019,7 +1020,8 @@ gen_gce_service_proxy() {
     "ISTIO_META_DNS_CAPTURE": "true",
     "ISTIO_META_AUTO_REGISTER_GROUP": $workload_name,
     "SERVICE_ACCOUNT": $service_account,
-    "CREDENTIAL_IDENTITY_PROVIDER": $credential_identity_provider
+    "CREDENTIAL_IDENTITY_PROVIDER": $credential_identity_provider,
+    "ASM_REVISION": $asm_revision
   },
   "service": {}
 }')

--- a/asm/vm/asm_vm
+++ b/asm/vm/asm_vm
@@ -1038,14 +1038,15 @@ gen_gce_service_proxy() {
 
 # Define the GCE software declaration for OS config.
 gce_software_declaration() {
-  jq -n --arg ingress_ip "${INGRESS_IP}" '{
+  jq -n --arg ingress_ip "${INGRESS_IP}"\
+  --arg asm_revision "${WORKLOAD_ASM_REVISION}" '{
   "softwareRecipes": [{
       "name": "install-gce-service-proxy-agent",
       "desired_state": "INSTALLED",
       "installSteps": [{
           "scriptRun": {
             "script": ("#!/bin/bash
-ISTIOD_ENTRY=\""+$ingress_ip+" istiod.istio-system.svc\"
+ISTIOD_ENTRY=\""+$ingress_ip+" istiod-"+$asm_revision+".istio-system.svc\"
 if ! grep -Fq ${ISTIOD_ENTRY} /etc/hosts; then
   echo \"${ISTIOD_ENTRY} # Added by Google Cloud for Anthos Service Mesh\" | sudo tee -a /etc/hosts
 fi
@@ -1069,6 +1070,7 @@ gen_instance_template_metadata() {
   jq -n --arg service_proxy_agent_bucket "${SERVICE_PROXY_AGENT_BUCKET}" \
   --arg root_cert "${ROOT_CERT}"\
   --arg declaration "${GCE_SOFTWARE_DECLARATION}"\
+  --arg asm_revision "${WORKLOAD_ASM_REVISION}"\
   --arg gce_service_proxy "${GCE_SERVICE_PROXY}" '[{
 "value": "true",
 "key": "enable-guest-attributes"
@@ -1088,6 +1090,10 @@ gen_instance_template_metadata() {
 {
   "value": $root_cert,
   "key": "rootcert"
+},
+{
+  "value": $asm_revision,
+  "key": "asm-revision"
 },
 {
   "value": $gce_service_proxy,

--- a/asm/vm/asm_vm
+++ b/asm/vm/asm_vm
@@ -1049,7 +1049,7 @@ gce_software_declaration() {
           "scriptRun": {
             "script": ("#!/bin/bash
 ISTIOD_ENTRY=\""+$ingress_ip+" istiod-"+$asm_revision+".istio-system.svc\"
-if ! grep -Fq ${ISTIOD_ENTRY} /etc/hosts; then
+if ! grep -Fq \"${ISTIOD_ENTRY}\" /etc/hosts; then
   echo \"${ISTIOD_ENTRY} # Added by Google Cloud for Anthos Service Mesh\" | sudo tee -a /etc/hosts
 fi
 SERVICE_PROXY_AGENT_BUCKET=$(curl \"http://metadata.google.internal/computeMetadata/v1/instance/attributes/gce-service-proxy-agent-bucket\" -H \"Metadata-Flavor: Google\")
@@ -1072,7 +1072,6 @@ gen_instance_template_metadata() {
   jq -n --arg service_proxy_agent_bucket "${SERVICE_PROXY_AGENT_BUCKET}" \
   --arg root_cert "${ROOT_CERT}"\
   --arg declaration "${GCE_SOFTWARE_DECLARATION}"\
-  --arg asm_revision "${WORKLOAD_ASM_REVISION}"\
   --arg gce_service_proxy "${GCE_SERVICE_PROXY}" '[{
 "value": "true",
 "key": "enable-guest-attributes"
@@ -1092,10 +1091,6 @@ gen_instance_template_metadata() {
 {
   "value": $root_cert,
   "key": "rootcert"
-},
-{
-  "value": $asm_revision,
-  "key": "asm-revision"
 },
 {
   "value": $gce_service_proxy,

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -2062,6 +2062,12 @@ configure_package() {
     kpt cfg set asm anthos.servicemesh.external_ca.ca_name "${CA_NAME}"
   fi
 
+  if [[ "${USE_VM}" -eq 1 ]]; then
+    kpt cfg set asm anthos.servicemesh.istiodHost "istiod-${REVISION_LABEL}.istio-system.svc.cluster.local"
+    kpt cfg set asm anthos.servicemesh.istiod-vs-name "istiod-vs-${REVISION_LABEL}"
+    kpt cfg set asm anthos.servicemesh.istiod-dr-name "istiod-dr-${REVISION_LABEL}"
+  fi
+
   if [[ "${CA}" == "mesh_ca" && -n "${_CI_TRUSTED_GCP_PROJECTS}" ]]; then
     # Gather the trust domain aliases from projects.
     TRUST_DOMAIN_ALIASES="${PROJECT_ID}.svc.id.goog"
@@ -2164,7 +2170,14 @@ EOF
 
   if [[ "${USE_VM}" -eq 1 ]]; then
     info "Exposing the control plane for VM workloads..."
-    retry 3 kubectl apply -f "${EXPOSE_ISTIOD_SERVICE}"
+    expose_istiod
+
+    # The default istiod service is exposed so that any fallback on the VM side
+    # to use the default Istiod service can still connect to the control plane.
+    kpt cfg set asm anthos.servicemesh.istiodHost "istiod.istio-system.svc.cluster.local"
+    kpt cfg set asm anthos.servicemesh.istiod-vs-name "istiod-vs"
+    kpt cfg set asm anthos.servicemesh.istiod-dr-name "istiod-dr"
+    expose_istiod
   fi
 
   outro
@@ -2177,6 +2190,10 @@ install_canonical_controller() {
   retry 3 kubectl wait --for=condition=available --timeout=600s \
       deployment/canonical-service-controller-manager -n asm-system
   info "...done!"
+}
+
+expose_istiod() {
+  retry 3 kubectl apply -f "${EXPOSE_ISTIOD_SERVICE}"
 }
 
 start_managed_control_plane() {


### PR DESCRIPTION
This allows VMs to use a different revision of Istiod during control plane canary upgrade.

/cc @maasen 