### PR TITLE
dont set default revision in meta

### DIFF
--- a/asm/vm/asm_vm
+++ b/asm/vm/asm_vm
@@ -1001,6 +1001,12 @@ EOF
 # Generate GCE service proxy definition for the instance template
 gen_gce_service_proxy() {
   local PROXY
+
+  local ASM_META_REVISION="${WORKLOAD_ASM_REVISION}"
+  if [ "${ASM_META_REVISION}" == "default" ]; then
+    ASM_META_REVISION=""
+  fi
+
   PROXY=$(jq -n --arg ingress_ip "${INGRESS_IP}" \
     --arg project_id "${PROJECT_ID}" \
     --arg workload_name "${WORKLOAD_NAME}" \
@@ -1009,7 +1015,7 @@ gen_gce_service_proxy() {
     --arg project_number "${PROJECT_NUMBER}" \
     --arg workload_namespace "${WORKLOAD_NAMESPACE}" \
     --arg service_account "${WORKLOAD_SERVICE_ACCOUNT}" \
-    --arg asm_revision "${WORKLOAD_ASM_REVISION}"\
+    --arg asm_revision "${ASM_META_REVISION}"\
     --arg credential_identity_provider "${CREDENTIAL_IDENTITY_PROVIDER}" \
     --arg network "${NETWORK}" \
     --arg asm_meta_version "${ASM_META_VERSION}" '{

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -2113,7 +2113,7 @@ configure_package() {
     kpt cfg set asm anthos.servicemesh.external_ca.ca_name "${CA_NAME}"
   fi
 
-  if [[ "${USE_VM}" -eq 1 ]] && [[ _CI_NO_REVISION -eq 0 ]]; then
+  if [[ "${USE_VM}" -eq 1 ]] && [[ "${_CI_NO_REVISION}" -eq 0 ]]; then
     kpt cfg set asm anthos.servicemesh.istiodHost "istiod-${REVISION_LABEL}.istio-system.svc.cluster.local"
     kpt cfg set asm anthos.servicemesh.istiod-vs-name "istiod-vs-${REVISION_LABEL}"
     kpt cfg set asm anthos.servicemesh.istiod-dr-name "istiod-dr-${REVISION_LABEL}"

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -2113,7 +2113,7 @@ configure_package() {
     kpt cfg set asm anthos.servicemesh.external_ca.ca_name "${CA_NAME}"
   fi
 
-  if [[ "${USE_VM}" -eq 1 ]]; then
+  if [[ "${USE_VM}" -eq 1 ]] && [[ _CI_NO_REVISION -eq 0 ]]; then
     kpt cfg set asm anthos.servicemesh.istiodHost "istiod-${REVISION_LABEL}.istio-system.svc.cluster.local"
     kpt cfg set asm anthos.servicemesh.istiod-vs-name "istiod-vs-${REVISION_LABEL}"
     kpt cfg set asm anthos.servicemesh.istiod-dr-name "istiod-dr-${REVISION_LABEL}"


### PR DESCRIPTION
It may be better for this logic to exist in the agent, but I'm testing against this workaround. 

similar logic: 

https://github.com/istio/istio/blob/386a2dbd7f71c16c0f47820d4f4cc3322ef87e2c/manifests/charts/istio-control/istio-discovery/templates/configmap.yaml#L60

https://github.com/istio/istio/blob/90e498421d5ccdb1c4631c63d8e30dc5d913308f/istioctl/cmd/workload.go#L511-L519
