### PR TITLE
handle default revision when fetching config map

### DIFF
--- a/asm/vm/asm_vm
+++ b/asm/vm/asm_vm
@@ -916,6 +916,9 @@ uses_environ_workload_identity() {
   local CURR_REVISION; CURR_REVISION="${1}";
 
   local CONFIGMAP; CONFIGMAP="istio-${CURR_REVISION}";
+  if [ "${CURR_REVISION}" == "default" ]; then
+      CONFIGMAP="istio"
+  fi
   if [[ "$(retry 2 kubectl get configmap -n istio-system \
     | grep -w -c "${CONFIGMAP}" || true)" -eq 0 ]]; then
     false


### PR DESCRIPTION
same as https://github.com/istio/istio/blob/90e498421d5ccdb1c4631c63d8e30dc5d913308f/istioctl/cmd/workload.go#L391

although the template doesn't have `if rev == default`, it assumes the revision isn't passed at all when it is `default`. 

Without this, an ASM installation with `_CI_NO_REVISION` will make the vm script error with `asm_vm: [ERROR]: The environ workload identity is not used in any of your ASM installation in the cluster`