### PR TITLE
Don't register with -e unless using a feature that requires it

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -687,7 +687,9 @@ FLAGS:
   are incompatible with --only_validate.
 
   -e|--enable_all                     Allow the script to perform all of the
-                                      individual enable actions below.
+                                      individual enable actions below. (Environ
+                                      registration won't happen unless necessary
+                                      for a selected option.)
      --enable_cluster_roles           Allow the script to attempt to set
                                       the necessary cluster roles.
      --enable_cluster_labels          Allow the script to attempt to set

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -488,41 +488,74 @@ can_modify_at_all() {
 }
 
 can_modify_cluster_roles() {
-  if [[ "${ENABLE_ALL}" -eq 0 && "${ENABLE_CLUSTER_ROLES}" -eq 0 ]] && \
-    ! is_managed || \
-    ! can_modify_at_all; then false; fi
+  if ! can_modify_at_all; then false; return; fi
+
+  if is_managed || [[ "${ENABLE_ALL}" -eq 1 || "${ENABLE_CLUSTER_ROLES}" -eq 1 ]]; then
+    true
+  else
+    false
+  fi
 }
 
 can_modify_cluster_labels() {
-  if [[ "${ENABLE_ALL}" -eq 0 && "${ENABLE_CLUSTER_LABELS}" -eq 0 ]] \
-    || ! can_modify_at_all; then false; fi
+  if ! can_modify_at_all; then false; return; fi
+
+  if [[ "${ENABLE_ALL}" -eq 1 || "${ENABLE_CLUSTER_LABELS}" -eq 1 ]]; then
+    true
+  else
+    false
+  fi
 }
 
 can_modify_gcp_apis() {
-  if [[ "${ENABLE_ALL}" -eq 0 && "${ENABLE_GCP_APIS}" -eq 0 ]] \
-    || ! can_modify_at_all; then false; fi
+  if ! can_modify_at_all; then false; return; fi
+
+  if [[ "${ENABLE_ALL}" -eq 1 || "${ENABLE_GCP_APIS}" -eq 1 ]]; then
+    true
+  else
+    false
+  fi
 }
 
 can_modify_gcp_iam_roles() {
-  if [[ "${ENABLE_ALL}" -eq 0 && "${ENABLE_GCP_IAM_ROLES}" -eq 0 ]] && \
-    ! is_managed ||
-    ! can_modify_at_all; then false; fi
+  if ! can_modify_at_all; then false; return; fi
+
+  if is_managed || [[ "${ENABLE_ALL}" -eq 1 || "${ENABLE_GCP_IAM_ROLES}" -eq 1 ]]; then
+    true
+  else
+    false
+  fi
 }
 
 can_modify_gcp_components() {
-  if [[ "${ENABLE_ALL}" -eq 0 && "${ENABLE_GCP_COMPONENTS}" -eq 0 ]] && \
-    ! is_managed || \
-    ! can_modify_at_all; then false; fi
+  if ! can_modify_at_all; then false; return; fi
+
+  if is_managed || [[ "${ENABLE_ALL}" -eq 1 || "${ENABLE_GCP_COMPONENTS}" -eq 1 ]]; then
+    true
+  else
+    false
+  fi
 }
 
 can_register_cluster() {
-  if [[ "${ENABLE_ALL}" -eq 0 && "${ENABLE_REGISTRATION}" -eq 0 ]] \
-    || ! can_modify_at_all; then false; fi
+  if ! can_modify_at_all; then false; return; fi
+
+  if [[ "${ENABLE_ALL}" -eq 1 && ("${USE_VM}" -eq 1 || "${USE_HUB_WIP}" -eq 1) ]] \
+    || [[ "${ENABLE_REGISTRATION}" -eq 1 ]]; then
+    true
+  else
+    false
+  fi
 }
 
 needs_asm() {
-  if [[ "${PRINT_CONFIG}" -eq 0 ]] && ! can_modify_at_all && ! should_validate; then false; fi
-  if only_enable; then false; fi
+  if only_enable; then false; return; fi
+
+  if [[ "${PRINT_CONFIG}" -eq 1 ]] || can_modify_at_all || should_validate; then
+    true
+  else
+    false
+  fi
 }
 
 enable_common_message() {

--- a/scripts/asm-installer/tests/run_cli_tests
+++ b/scripts/asm-installer/tests/run_cli_tests
@@ -341,6 +341,14 @@ test_main() {
   fi
   echo "***"
 
+  if can_register_cluster; then
+    echo "Enable all shouldn't register to environ when unnecessary: FAIL"
+    ((++FAILURES))
+  else
+    echo "Enable all shouldn't register to environ when unnecessary: PASS"
+  fi
+  echo "***"
+
   clear_variables
   parse_args ${CMD} --enable-cluster-labels
 
@@ -348,6 +356,7 @@ test_main() {
     || can_modify_cluster_roles \
     || ! can_modify_cluster_labels \
     || can_modify_gcp_apis \
+    || can_register_cluster \
     || can_modify_gcp_components \
     || can_modify_gcp_iam_roles; then
     echo "Permissions with --enable-cluster-labels flag: FAIL"
@@ -364,6 +373,7 @@ test_main() {
     || ! can_modify_cluster_roles \
     || can_modify_cluster_labels \
     || can_modify_gcp_apis \
+    || can_register_cluster \
     || can_modify_gcp_components \
     || can_modify_gcp_iam_roles; then
     echo "Permissions with --enable-cluster-roles flag: FAIL"
@@ -380,6 +390,7 @@ test_main() {
     || can_modify_cluster_roles \
     || can_modify_cluster_labels \
     || ! can_modify_gcp_apis \
+    || can_register_cluster \
     || can_modify_gcp_components \
     || can_modify_gcp_iam_roles; then
     echo "Permissions with --enable-gcp-apis flag: FAIL"
@@ -396,6 +407,7 @@ test_main() {
     || can_modify_cluster_roles \
     || can_modify_cluster_labels \
     || can_modify_gcp_apis \
+    || can_register_cluster \
     || ! can_modify_gcp_components \
     || can_modify_gcp_iam_roles; then
     echo "Permissions with --enable-gcp-components flag: FAIL"
@@ -412,6 +424,7 @@ test_main() {
     || can_modify_cluster_roles \
     || can_modify_cluster_labels \
     || can_modify_gcp_apis \
+    || can_register_cluster \
     || can_modify_gcp_components \
     || ! can_modify_gcp_iam_roles; then
     echo "Permissions with --enable-gcp-iam-roles flag: FAIL"
@@ -428,12 +441,24 @@ test_main() {
     || ! can_modify_cluster_roles \
     || can_modify_cluster_labels \
     || can_modify_gcp_apis \
+    || can_register_cluster \
     || ! can_modify_gcp_components \
     || ! can_modify_gcp_iam_roles; then
     echo "Permissions with --managed flag: FAIL"
     ((++FAILURES))
   else
     echo "Permissions with --managed flag: PASS"
+  fi
+  echo "***"
+
+  clear_variables
+  parse_args ${CMD} --enable-all --option vm --option hub_meshca
+
+  if ! can_register_cluster; then
+    echo "Enable all registers with environ when necessary: FAIL"
+    ((++FAILURES))
+  else
+    echo "Enable all registers with environ when necessary: PASS"
   fi
   echo "***"
 


### PR DESCRIPTION
Added/updated tests, also I had to refactor the `can_*` functions because the negative logic was too difficult to read.