### PR TITLE
Switch to staging meshconfig API for managed control plane

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1601,7 +1601,7 @@ bind_user_to_iam_policy(){
   while read -r role; do
   retry 3 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
     --member "${GCLOUD_MEMBER}" \
-    --role="${role}" >/dev/null
+    --role="${role}" --condition=None >/dev/null
   done <<EOF
 ${ROLES}
 EOF

--- a/scripts/asm-installer/tests/run_basic_suite_managed
+++ b/scripts/asm-installer/tests/run_basic_suite_managed
@@ -15,7 +15,9 @@ main() {
   # CLI setup
   parse_args "$@"
 
+  sed -i 's/meshconfig\.googleapis\.com/staging-meshconfig.sandbox.googleapis.com/g' ../install_asm
   run_basic_test "install" "mesh_ca" "--managed"; RETVAL=$?;
+  sed -i 's/staging-meshconfig.sandbox.googleapis.com/meshconfig\.googleapis\.com/g' ../install_asm
   cleanup_lt_cluster "${LT_NAMESPACE}" "${OUTPUT_DIR}" "${REV}"
 
   exit "${RETVAL}"

--- a/scripts/asm-installer/tests/setup_longterm_cluster
+++ b/scripts/asm-installer/tests/setup_longterm_cluster
@@ -75,7 +75,7 @@ setup_cluster() {
     -n "${cluster}" \
     -p "${LT_PROJECT_ID}" \
     -m install \
-    --only-enable -e
+    --only-enable -e -v
 }
 
 setup_cluster "${LT_CLUSTER_NAME}"


### PR DESCRIPTION
Production meshconfig API forces us to use a very old Istiod
image version that was created in Jan. The new gateway image
with the new auth is not compatible with that version.