### PR TITLE
Include directions for upgrating validation fix on upgrade/migration

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -36,6 +36,7 @@ REV="${REV:=1}"; readonly REV;
 K8S_MINOR=0
 
 ### File related constants ###
+VALIDATION_FIX_FILE_NAME="istiod-service.yaml"
 ISTIO_FOLDER_NAME=""
 ISTIOCTL_REL_PATH=""
 BASE_REL_PATH=""
@@ -310,7 +311,7 @@ init() {
   ISTIOCTL_REL_PATH="${ISTIO_FOLDER_NAME}/bin/istioctl"; readonly ISTIOCTL_REL_PATH;
   BASE_REL_PATH="${ISTIO_FOLDER_NAME}/manifests/charts/base/files/gen-istio-cluster.yaml"; readonly BASE_REL_PATH;
   PACKAGE_DIRECTORY="asm/istio"; readonly PACKAGE_DIRECTORY;
-  VALIDATION_FIX_SERVICE="${PACKAGE_DIRECTORY}/istiod-service.yaml"; readonly VALIDATION_FIX_SERVICE;
+  VALIDATION_FIX_SERVICE="${PACKAGE_DIRECTORY}/${VALIDATION_FIX_FILE_NAME}"; readonly VALIDATION_FIX_SERVICE;
   OPTIONS_DIRECTORY="${PACKAGE_DIRECTORY}/options"; readonly OPTIONS_DIRECTORY;
   OPERATOR_MANIFEST="${PACKAGE_DIRECTORY}/istio-operator.yaml"; readonly OPERATOR_MANIFEST;
   BETA_CRD_MANIFEST="${OPTIONS_DIRECTORY}/v1beta1-crds.yaml"; readonly BETA_CRD_MANIFEST;
@@ -2273,6 +2274,8 @@ install_asm() {
   if ! does_istiod_exist && [[ "${_CI_NO_REVISION}" -ne 1 ]]; then
     info "Installing validation webhook fix..."
     retry 3 kubectl apply -f "${VALIDATION_FIX_SERVICE}"
+  elif [[ "${MODE}" == "upgrade" ]]; then
+    cp "${VALIDATION_FIX_SERVICE}" .
   fi
 
   local PARAMS
@@ -2406,10 +2409,13 @@ outro() {
   info "instead of installing a new one."
 
 
-  if [[ "${MODE}" = "migrate" ]]; then
+  if [[ "${MODE}" = "migrate" || "${MODE}" = "upgrade" ]]; then
     info "Please verify the new control plane and then: 1) migrate your workloads 2) remove old control plane."
     info "For more information, see:"
     info "https://cloud.google.com/service-mesh/docs/upgrading-gke#redeploying_workloads"
+    info "Before removing the old control plane, update the service used by validation if necessary."
+    info "If the 'istiod' service has a revision label different than ${REVISION_LABEL}, then apply"
+    info "${OUTPUT_DIR}/${VALIDATION_FIX_FILE_NAME} using 'kubectl apply'"
   elif [[ "${MODE}" = "install" ]]; then
     info "To finish the installation, enable Istio sidecar injection and restart your workloads."
     info "For more information, see:"

--- a/scripts/asm-installer/tests/run_migration_suite_meshca
+++ b/scripts/asm-installer/tests/run_migration_suite_meshca
@@ -67,6 +67,7 @@ main() {
       -p ${PROJECT_ID} \
       -m migrate \
       -c mesh_ca \
+      -D mesh_migration \
       -s ${SERVICE_ACCOUNT} \
       -k ${KEY_FILE} -v -e"
     ../install_asm \
@@ -75,6 +76,7 @@ main() {
       -p "${PROJECT_ID}" \
       -m migrate \
       -c mesh_ca \
+      -D mesh_migration \
       -s "${SERVICE_ACCOUNT}" \
       -k "${KEY_FILE}" -v -e \
       2>&1 | tee "${CLUSTER_NAME}" &
@@ -84,12 +86,14 @@ main() {
       -n ${CLUSTER_NAME} \
       -p ${PROJECT_ID} \
       -m migrate \
+      -D mesh_migration \
       -c mesh_ca -v -e"
     ../install_asm \
       -l "${CLUSTER_LOCATION}" \
       -n "${CLUSTER_NAME}" \
       -p "${PROJECT_ID}" \
       -m migrate \
+      -D mesh_migration \
       -c mesh_ca -v -e \
       2>&1 | tee "${CLUSTER_NAME}" &
   fi
@@ -98,7 +102,7 @@ main() {
 
   LABEL="$(grep -o -m 1 'istio.io/rev=\S*' "${CLUSTER_NAME}")"
   rm "${CLUSTER_NAME}"
-  echo "Relabelling namsepace with ${LABEL}..."
+  echo "Relabelling namespace with ${LABEL}..."
   label_with_revision "${NAMESPACE}" "${LABEL}"
   echo "Performing a rolling restart of the demo app..."
   roll "${NAMESPACE}"
@@ -121,6 +125,13 @@ main() {
     set +e
     verify_demo_app "${GATEWAY}" || SUCCESS=1
     set -e
+  fi
+
+  echo "Checking for validation service yaml..."
+
+  if [[ ! -f mesh_migration/istiod-service.yaml ]]; then
+    echo "Couldn't find validation service at mesh_migration/istiod-service.yaml!"
+    SUCCESS=1
   fi
 
   # Cluster teardown


### PR DESCRIPTION
Right now we don't give any guidance for upgrades/migrations if the existing installation uses a custom istiod service as a fix for the OSS validatingwebhook bug. This commit copies the config to a known location and adds steps to the outro.