### PR TITLE
vm eastwest iop should not have name

### DIFF
--- a/asm/istio/options/vm.yaml
+++ b/asm/istio/options/vm.yaml
@@ -15,8 +15,6 @@
 ---
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
-metadata:
-  name: eastwest
 spec:
   components:
     ingressGateways:


### PR DESCRIPTION
Without this, the IstioOperator will overwrite other parts of the installation. 

the istiod deployment/service, mutating webhook configmap/config, validating webhook config and probably a ton of other things end up with `install.operator.istio.io/owning-resource: eastwest` which is incorrect. 

