### PR TITLE
change size of init vm for centos to 20gb

### DIFF
--- a/scripts/asm-installer/asm_vm
+++ b/scripts/asm-installer/asm_vm
@@ -1409,7 +1409,7 @@ gen_default_instance_template() {
         "initializeParams": {
           "sourceImage": "projects/debian-cloud/global/images/family/debian-10",
           "diskType": "pd-standard",
-          "diskSizeGb": "10"
+          "diskSizeGb": "20"
         }
       }
     ],


### PR DESCRIPTION
centos distros disk size needs to be at least 20 gb to work.