### PR TITLE
Backport revisioned ingressgateways to 17

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -254,3 +254,35 @@ openAPI:
           values:
           - marker: ENVIRON_PROJECT_ID
             ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'
+    io.k8s.cli.substitutions.istio-ingressgateway-deploy-name:
+      x-k8s-cli:
+        substitution:
+          name: istio-ingressgateway-deploy-name
+          pattern: istio-ingressgateway-ASM_REV
+          values:
+          - marker: ASM_REV
+            ref: '#/definitions/io.k8s.cli.setters.anthos.servicemesh.rev'
+    io.k8s.cli.setters.anthos.servicemesh.custom-ingressgateway-name:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: anthos.servicemesh.custom-ingressgateway-name
+          value: "INGRESSGATEWAY_NAME"
+          isSet: true
+    io.k8s.cli.setters.anthos.servicemesh.custom-ingressgateway-namespace:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: anthos.servicemesh.custom-ingressgateway-namespace
+          value: "istio-system"
+          isSet: true
+    io.k8s.cli.substitutions.custom-ingressgateway-deploy-name:
+      x-k8s-cli:
+        substitution:
+          name: custom-ingressgateway-deploy-name
+          pattern: INGRESSGATEWAY_NAME-ASM_REV
+          values:
+          - marker: ASM_REV
+            ref: '#/definitions/io.k8s.cli.setters.anthos.servicemesh.rev'
+          - marker: INGRESSGATEWAY_NAME
+            ref: '#/definitions/io.k8s.cli.setters.anthos.servicemesh.custom-ingressgateway-name'

--- a/asm/istio/options/revisioned-custom-ingressgateway.yaml
+++ b/asm/istio/options/revisioned-custom-ingressgateway.yaml
@@ -1,0 +1,61 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: INGRESSGATEWAY_NAME # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.custom-ingressgateway-name"}
+spec:
+  components:
+    ingressGateways:
+    - name: INGRESSGATEWAY_NAME-ASM_REV # {"$ref":"#/definitions/io.k8s.cli.substitutions.custom-ingressgateway-deploy-name"}
+      enabled: true
+      namespace: istio-system # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.custom-ingressgateway-namespace"}
+      k8s:
+        hpaSpec:
+          maxReplicas: 5
+          minReplicas: 2
+        env:
+        - name: ISTIO_META_ROUTER_MODE
+          value: standard
+        service:
+          ports:
+          - name: status-port
+            port: 15021
+            protocol: TCP
+            targetPort: 15021
+          - name: http2
+            port: 80
+            protocol: TCP
+            targetPort: 8080
+          - name: https
+            port: 443
+            protocol: TCP
+            targetPort: 8443
+          - name: tcp-istiod
+            port: 15012
+            protocol: TCP
+            targetPort: 15012
+          - name: tls
+            port: 15443
+            protocol: TCP
+            targetPort: 15443
+        # Rename the service to still use istio-ingressgateway
+        overlays:
+        - apiVersion: extensions/v1beta1
+          kind: Service
+          name: INGRESSGATEWAY_NAME-ASM_REV # {"$ref":"#/definitions/io.k8s.cli.substitutions.custom-ingressgateway-deploy-name"}
+          patches:
+          - path: metadata.name
+            value: INGRESSGATEWAY_NAME # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.custom-ingressgateway-name"}

--- a/asm/istio/options/revisioned-istio-ingressgateway.yaml
+++ b/asm/istio/options/revisioned-istio-ingressgateway.yaml
@@ -1,0 +1,62 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    ingressGateways:
+    # Disable istio-ingressgateway to avoid downtime from in-place upgrade
+    - name: istio-ingressgateway
+      enabled: false
+    # Workaround to use revision based deployments for istio-ingressgateway
+    - name: istio-ingressgateway-ASM_REV # {"$ref":"#/definitions/io.k8s.cli.substitutions.istio-ingressgateway-deploy-name"}
+      enabled: true
+      k8s:
+        hpaSpec:
+          maxReplicas: 5
+          minReplicas: 2
+        env:
+        - name: ISTIO_META_ROUTER_MODE
+          value: standard
+        service:
+          ports:
+          - name: status-port
+            port: 15021
+            protocol: TCP
+            targetPort: 15021
+          - name: http2
+            port: 80
+            protocol: TCP
+            targetPort: 8080
+          - name: https
+            port: 443
+            protocol: TCP
+            targetPort: 8443
+          - name: tcp-istiod
+            port: 15012
+            protocol: TCP
+            targetPort: 15012
+          - name: tls
+            port: 15443
+            protocol: TCP
+            targetPort: 15443
+        # Rename the service to still use istio-ingressgateway
+        overlays:
+        - apiVersion: extensions/v1beta1
+          kind: Service
+          name: istio-ingressgateway-ASM_REV # {"$ref":"#/definitions/io.k8s.cli.substitutions.istio-ingressgateway-deploy-name"}
+          patches:
+          - path: metadata.name
+            value: istio-ingressgateway


### PR DESCRIPTION
Cherrypick of 

https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/pull/388/files
https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/pull/431/files

Tested on a cluster by upgrading 1.6 to 1.7