### PR TITLE
Properly validate commands in compatibility vars

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -414,12 +414,13 @@ EOF
 ${NEEDLES}
 EOF
 
-  if [[ -n "${NOTFOUND}" ]]; then NOTFOUND="$(strip_last_char "${NOTFOUND}")"; fi
+  if [[ -n "${NOTFOUND}" ]]; then NOTFOUND="$(strip_trailing_commas "${NOTFOUND}")"; fi
   echo "${NOTFOUND}"
 }
 
-strip_last_char() {
-  echo "${1:0:$((${#1} - 1))}"
+strip_trailing_commas() {
+  # shellcheck disable=SC2001
+  echo "${1}" | sed 's/,*$//g'
 }
 
 configure_kubectl(){
@@ -1310,12 +1311,22 @@ awk
 $AGCLOUD
 grep
 jq
-kpt
 $AKUBECTL
+$AKPT
 sed
 tr
 head
 csplit
+EOF
+
+  while read -r FLAG; do
+    if [[ -z "${!FLAG}" ]]; then
+      NOTFOUND="${FLAG},${NOTFOUND}"
+    fi
+  done <<EOF
+AKUBECTL
+AGCLOUD
+AKPT
 EOF
 
   if [[ "${CUSTOM_CA}" -eq 1 ]]; then
@@ -1326,8 +1337,8 @@ EOF
     fi
   fi
 
-  if [[ -n "${NOTFOUND}" ]]; then
-    NOTFOUND="$(strip_last_char "${NOTFOUND}")"
+  if [[ "${#NOTFOUND}" -gt 1 ]]; then
+    NOTFOUND="$(strip_trailing_commas "${NOTFOUND}")"
     for dep in $(echo "${NOTFOUND}" | tr ' ' '\n'); do
       warn "Dependency not found: ${dep}"
     done

--- a/scripts/asm-installer/tests/run_cli_tests
+++ b/scripts/asm-installer/tests/run_cli_tests
@@ -83,6 +83,11 @@ warn_pause() {
   WARNED=1
 }
 
+warn() {
+  echo "[WARNING(fake)]: ${1}" >&2
+  WARNED=1
+}
+
 NODE_POOL=""
 list_valid_pools() {
   echo "${NODE_POOL}"
@@ -557,6 +562,7 @@ EOF
     echo "local_iam_user detects not logged in state: PASS"
   fi
   echo "***"
+  FATAL_EXITS=1
 
   #################
   # node pool validation should handle zonal, regional pools with mixed types
@@ -602,6 +608,25 @@ EOF
   fi
   echo "***"
 
+  #################
+  # CLI dependency validation should fail when compatibility variables are unset
+  #################
+
+  WARNED=0
+  FATAL_EXITS=0
+  AKPT=""
+  AGCLOUD="gcloud"
+  AKUBECTL="kubectl"
+  validate_cli_dependencies
+  FATAL_EXITS=1
+
+  if [[ "${WARNED}" -eq 0 ]]; then
+    echo "validate_cli_dependencies handles compatibility variables: FAIL"
+    ((++FAILURES))
+  else
+    echo "validate_cli_dependencies handles compatibility variables: PASS"
+  fi
+  echo "***"
 
   #################
   echo "There were ${FAILURES} failures."


### PR DESCRIPTION
We set a few variables for commands that might differ in functionality/location between environments. (e.g. GNU/BSD readlink). There are certain cases where these variables wouldn't properly trigger validation, so we should check for empty values explicitly.

Fixes #539 