### PR TITLE
Only override boot disk name when creating instance template

### DIFF
--- a/scripts/asm-installer/asm_vm
+++ b/scripts/asm-installer/asm_vm
@@ -1462,7 +1462,7 @@ create_gce_instance_template() {
       --format=json \
       --project="${PROJECT_ID}" \
       | jq --arg name "${NEW_INSTANCE_TEMPLATE}" \
-      '.name=$name | .properties.disks[].deviceName=$name' || true)"
+      '.name=$name | .properties.disks[0].deviceName=$name' || true)"
 
     EXISTING_METADATA="$(echo "${INSTANCE_TEMPLATE_REQ}" \
       | jq '.properties.metadata.items')"


### PR DESCRIPTION
Boot disk on GCE is required and is always at index 0 of the GCE disk array.