### PR TITLE
Add logging writer role to list of MCP SA required perms

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1791,6 +1791,7 @@ required_iam_roles_mcp_sa() {
 roles/serviceusage.serviceUsageConsumer
 roles/container.admin
 roles/monitoring.metricWriter
+roles/logging.logWriter
 EOF
 }
 


### PR DESCRIPTION
This PR is part of a set of changes for ASM that involves MCP logging direct to customer project. It mirrors the permissions granted for the monitoring API (metrics writer).

/cc @costinm @qfel