### PR TITLE
Kpt pkg get from tag

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -296,7 +296,7 @@ init() {
     RELEASE="${MAJOR}.${MINOR}-alpha.${REV}"
     REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}"
     KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=master}"
-  elif [[ "$(version_message)" =~ [0-9]+\.[0-9]+\.[0-9]+-asm[0-9]+\+config[0-9]+ ]]; then
+  elif [[ "$(version_message)" =~ [0-9]+\.[0-9]+\.[0-9]+-asm\.[0-9]+\+config[0-9]+ ]]; then
     RELEASE="${MAJOR}.${MINOR}.${POINT}-asm.${REV}"
     REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}-${REV}"
     KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=$(version_message)}"

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -296,7 +296,7 @@ init() {
     RELEASE="${MAJOR}.${MINOR}-alpha.${REV}"
     REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}"
     KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=master}"
-  elif [[ "$(version_message)" =~ \d+\.\d+\.\d+-asm\d++config\d+ ]]; then
+  elif [[ "$(version_message)" =~ [0-9]+\.[0-9]+\.[0-9]+-asm[0-9]++config[0-9]+ ]]; then
     RELEASE="${MAJOR}.${MINOR}.${POINT}-asm.${REV}"
     REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}-${REV}"
     KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=$(version_message)}"

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -296,6 +296,10 @@ init() {
     RELEASE="${MAJOR}.${MINOR}-alpha.${REV}"
     REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}"
     KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=master}"
+  elif [[ "$(version_message)" =~ "\d+\.\d+\.\d+-asm\d++config\d+" ]]; then
+    RELEASE="${MAJOR}.${MINOR}.${POINT}-asm.${REV}"
+    REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}-${REV}"
+    KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=$(version_message)}"
   else
     RELEASE="${MAJOR}.${MINOR}.${POINT}-asm.${REV}"
     REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}-${REV}"

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -296,7 +296,7 @@ init() {
     RELEASE="${MAJOR}.${MINOR}-alpha.${REV}"
     REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}"
     KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=master}"
-  elif [[ "$(version_message)" =~ [0-9]+\.[0-9]+\.[0-9]+-asm\.[0-9]+\+config[0-9]+ ]]; then
+  elif [[ "$(version_message)" =~ ^[0-9]+\.[0-9]+\.[0-9]+-asm\.[0-9]+\+config[0-9]+$ ]]; then
     RELEASE="${MAJOR}.${MINOR}.${POINT}-asm.${REV}"
     REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}-${REV}"
     KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=$(version_message)}"

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -296,7 +296,7 @@ init() {
     RELEASE="${MAJOR}.${MINOR}-alpha.${REV}"
     REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}"
     KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=master}"
-  elif [[ "$(version_message)" =~ [0-9]+\.[0-9]+\.[0-9]+-asm[0-9]++config[0-9]+ ]]; then
+  elif [[ "$(version_message)" =~ [0-9]+\.[0-9]+\.[0-9]+-asm[0-9]+\+config[0-9]+ ]]; then
     RELEASE="${MAJOR}.${MINOR}.${POINT}-asm.${REV}"
     REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}-${REV}"
     KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=$(version_message)}"

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -296,7 +296,7 @@ init() {
     RELEASE="${MAJOR}.${MINOR}-alpha.${REV}"
     REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}"
     KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=master}"
-  elif [[ "$(version_message)" =~ "\d+\.\d+\.\d+-asm\d++config\d+" ]]; then
+  elif [[ "$(version_message)" =~ \d+\.\d+\.\d+-asm\d++config\d+ ]]; then
     RELEASE="${MAJOR}.${MINOR}.${POINT}-asm.${REV}"
     REVISION_LABEL="${_CI_REVISION_PREFIX}asm-${MAJOR}${MINOR}${POINT}-${REV}"
     KPT_BRANCH="${_CI_ASM_KPT_BRANCH:=$(version_message)}"


### PR DESCRIPTION
This PR adds a condition so that if the version is properly set, `kpt pkg get` will use the version/tag instead of the branch name. 