### PR TITLE
update to simulate the previous validation logic

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1804,25 +1804,26 @@ EOF
 required_iam_roles() {
   # meshconfig.admin - required for init, stackdriver, UI elements, etc.
   # servicemanagement.admin/serviceusage.serviceUsageAdmin - enables APIs
-  if can_modify_gcp_components || \
+  if should_validate || \
+     can_modify_gcp_components || \
      can_modify_cluster_labels || \
      can_modify_cluster_roles; then
     echo roles/container.admin
   fi
-  if can_modify_gcp_components; then
+  if should_validate || can_modify_gcp_components; then
     echo roles/meshconfig.admin
   fi
-  if can_modify_gcp_apis; then
+  if should_validate || can_modify_gcp_apis; then
     echo roles/servicemanagement.admin
     echo roles/serviceusage.serviceUsageAdmin
   fi
-  if can_modify_gcp_iam_roles; then
+  if should_validate || can_modify_gcp_iam_roles; then
     echo roles/resourcemanager.projectIamAdmin
   fi
   if is_sa; then
     echo roles/iam.serviceAccountAdmin
   fi
-  if can_register_cluster; then
+  if should_validate || can_register_cluster; then
     echo roles/gkehub.admin
   fi
   if [[ "${CA}" = "gcp_cas" ]]; then


### PR DESCRIPTION
After #577 is introduced, `--only_validate` does not work anymore and it would misleadingly appear to the user that most of the IAM roles are not required anymore if they try to validate only (since we added logic to only conditionally require certain roles). This PR will simulate the previous validation logic that basically list all the required IAM roles. User could use this as a reference to the complete list of IAM roles required. 