### PR TITLE
Add special case for owner role

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1759,6 +1759,11 @@ exit_if_out_of_iam_policy() {
     --flatten='bindings[].members' \
     --filter="bindings.members:$(iam_user)" \
     --format='value(bindings.role)')"
+
+  if [[ "${MEMBER_ROLES}" = *"roles/owner"* ]]; then
+    return
+  fi
+
   local REQUIRED; REQUIRED="$(required_iam_roles)";
 
   local NOTFOUND; NOTFOUND="$(find_missing_strings "${REQUIRED}" "${MEMBER_ROLES}")"

--- a/scripts/asm-installer/tests/fake_gcloud
+++ b/scripts/asm-installer/tests/fake_gcloud
@@ -41,6 +41,11 @@ if [[ "${*}" == *"this_should_fail"* ]]; then
   exit 1
 fi
 
+if [[ "${*}" == *"get-iam-policy"*"owner_this_should_pass"* ]]; then
+  echo roles/owner
+  exit 0
+fi
+
 if [[ "${*}" == *"get-iam-policy"*"this_should_pass"* ]]; then
   cat <<EOF
 roles/servicemanagement.admin

--- a/scripts/asm-installer/tests/run_cli_tests
+++ b/scripts/asm-installer/tests/run_cli_tests
@@ -137,6 +137,29 @@ test_main() {
   echo "***"
 
   #################
+  # The owner role by itself should also pass
+  #################
+
+  CMD="-l this_should_pass"
+  CMD="${CMD} -n this_should_pass"
+  CMD="${CMD} -p owner_this_should_pass"
+  CMD="${CMD} -m install"
+  CMD="${CMD} -c mesh_ca"
+  CMD="${CMD} --only_validate"
+
+  RETVAL=0
+  clear_variables
+  _="$(_CI_I_AM_A_TEST_ROBOT=1 main ${CMD})" || RETVAL="${?}"
+
+  if [[ "${RETVAL}" -eq 0 ]]; then
+    echo "Passes with owner: PASS"
+  else
+    echo "Passes with owner: FAIL"
+    ((++FAILURES))
+  fi
+  echo "***"
+
+  #################
   # Should fail on non-existing project
   #################
 


### PR DESCRIPTION
There's no reason to check any other role for project owners.