### PR TITLE
istio option: Remove hardcoding TrustDomainAlias for ca migration. Al…

### DIFF
--- a/asm/istio/options/ca-migration-meshca.yaml
+++ b/asm/istio/options/ca-migration-meshca.yaml
@@ -25,5 +25,3 @@ spec:
     defaultConfig:
       proxyMetadata:
         PROXY_CONFIG_XDS_AGENT: "true"
-    trustDomainAliases:
-      - cluster.local


### PR DESCRIPTION
…low base overlays to configure this for control-plane via existing kpt setter

anthos.servicemesh.trustDomainAliases