### PR TITLE
Change service account detection pattern

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1835,7 +1835,7 @@ local_iam_user() {
 
   local ACCOUNT_TYPE
   ACCOUNT_TYPE="user"
-  if is_sa || [[ "${ACCOUNT_NAME}" = *.iam.gserviceaccount.com ]]; then
+  if is_sa || [[ "${ACCOUNT_NAME}" = *.gserviceaccount.com ]]; then
     ACCOUNT_TYPE="serviceAccount"
   fi
 


### PR DESCRIPTION
Using a more broad pattern for detecting if current gcloud account is a service account or not. Old pattern was missing *@cloudbuild.gserviceaccount.com.

Proposed for for https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/issues/630