### PR TITLE
Install istio-cni with securityContext for SELinux

### DIFF
--- a/asm/istio/options/cni-selinux.yaml
+++ b/asm/istio/options/cni-selinux.yaml
@@ -1,0 +1,37 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START docs]
+---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    cni:
+      enabled: true
+      namespace: kube-system
+      k8s:
+        overlays:
+          - kind: DaemonSet
+            name: istio-cni-node
+            patches:
+              - path: spec.template.spec.containers.[name:install-cni].securityContext
+                value: {"privileged": true}
+  values:
+    cni:
+      cniBinDir: /home/kubernetes/bin
+      excludeNamespaces:
+        - istio-system
+        - kube-system
+# [END docs]


### PR DESCRIPTION
The `istioinstall-cni` container needs a `securityContext` with `Privileged: true` to install `istio-cni` with SELinux enabled.

Related discussion on Istio PR https://github.com/istio/istio/pull/32360
