### PR TITLE
Do not explicitly specify COS where not needed

### DIFF
--- a/scripts/asm-installer/tests/common.sh
+++ b/scripts/asm-installer/tests/common.sh
@@ -268,7 +268,6 @@ create_working_cluster() {
     --no-enable-basic-auth \
     --release-channel "regular" \
     --machine-type "e2-standard-4" \
-    --image-type "COS" \
     --disk-type "pd-standard" \
     --disk-size "100" \
     --num-nodes "4" \


### PR DESCRIPTION
Starting with [GKE node version 1.19](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19), COS image type is deprecated. I suggest to not explicitly specify any parameters where defaults would work.