### PR TITLE
update dev guide for writing/running tests

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -37,10 +37,10 @@ We integrated [`bats`](https://github.com/bats-core/bats-core) as our
 testing system. To add tests, read the
 [official documentation](https://bats-core.readthedocs.io/en/latest/)
 and update/add `*.bats` files to the `asmcli/tests` folder.
-If there are any set-ups that could be shared among tests, update
+If there's any set-up that could be shared among tests, update
 `unit_test_common.bash` in the test folder.
 
-The `//:test` target will by default run all the tests. If you want
+The `:test` target will by default run all the tests. If you want
 finer-grained test targets, add new `sh_test` targets to `BUILD` and
 attach the relevant test files.
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -30,3 +30,28 @@ bazel clean --expunge_async
 * Don't add `#!/usr/bin/env bash` or equivalent lines to any modules/files. This line will be added during the compilation.
 * Put all code in functions. The merge logic will add the call to `main`. In other words, don't add any entry point to actually
 execute the script.
+
+
+## Writing Tests
+We integrated [`bats`](https://github.com/bats-core/bats-core) as our
+testing system. To add tests, read the
+[official documentation](https://bats-core.readthedocs.io/en/latest/)
+and update/add `*.bats` files to the `asmcli/tests` folder.
+If there are any set-ups that could be shared among tests, update
+`unit_test_common.bash` in the test folder.
+
+The `//:test` target will by default run all the tests. If you want
+finer-grained test targets, add new `sh_test` targets to `BUILD` and
+attach the relevant test files.
+
+
+## Running Tests
+To run tests,
+```shell
+bazel test $TEST_TARGET
+```
+
+Since we use `bazel`, the complete `bats` logs are not streamed to the
+terminal. The terminal will show basic information about whether
+the tests passed, but the entire log could be found in
+`bazel-testlogs/test.log`.


### PR DESCRIPTION
Now that the initial `bats` integration is merged, we update the dev guide to document the behavior and instructions.