### PR TITLE
Adjust container commnad path for istio-cni-repair

### DIFF
--- a/asm/istio/options/cni-managed.yaml
+++ b/asm/istio/options/cni-managed.yaml
@@ -186,7 +186,7 @@ spec:
               name: cni-net-dir
         - name: repair-cni
           image: "IMAGE_HUB/install-cni:IMAGE_TAG"  # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-cni-image"}
-          command: ["/opt/cni/bin/istio-cni-repair"]
+          command: ["/opt/local/bin/istio-cni-repair"]
           env:
             - name: "REPAIR_NODE-NAME"
               valueFrom:


### PR DESCRIPTION
Upstream has modified the template in 1.10.
https://github.com/istio/istio/pull/31906
This change is needed in order to use the new image in master branch
Scritaro. This change doesn't need to be cherry-picked to 1.9
since it's not affected.