### PR TITLE
Enable CNI installation by default for MCP.

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -122,6 +122,7 @@ PRINT_VERSION=0
 CUSTOM_CA=0
 USE_HUB_WIP=0
 USE_MCP_CNI=0
+INSTALL_MCP_CNI=0
 USE_VM=0
 ENVIRON_PROJECT_ID=""
 HUB_IDP_URL=""
@@ -920,6 +921,7 @@ parse_args() {
 
         if [[ "${2}" == "cni-managed" ]]; then
           USE_MCP_CNI=1
+          INSTALL_MCP_CNI=1
           shift 2
           continue
         fi
@@ -972,6 +974,7 @@ parse_args() {
         ;;
       --managed)
         MANAGED=1
+        INSTALL_MCP_CNI=1
         REVISION_LABEL="asm-managed"
         shift 1
         ;;
@@ -2745,7 +2748,7 @@ scrape_managed_urls() {
 }
 
 install_managed_components() {
-  if [[ "${USE_MCP_CNI}" -eq 1 ]]; then
+  if [[ "${INSTALL_MCP_CNI}" -eq 1 ]]; then
     info "Installing CNI into the cluster..."
     kubectl apply -f "${MANAGED_CNI}"
   fi


### PR DESCRIPTION
Separate CNI installation and enable in install_asm. Update the logic to always install CNI when using MCP, and actually enable CNI when `cni-managed` is set. Internal tracking bug [b/189281678](https://b.corp.google.com/issues/189281678).

cc @mandarjog @costinm @zerobfd for feedback.