### PR TITLE
Better error message for showing executed command when all retries failed

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -428,6 +428,8 @@ retry() {
     warn "Failed, retrying...($((i+1)) of ${MAX_TRIES})"
     sleep $((2 * i + 2))
   done
+  local CMD="'$*'"
+  warn "Command $CMD failed."
   false
 }
 


### PR DESCRIPTION
Hi team, 

Current install_asm command is hard to debug when it failed with some error of called command from it because it won't show what commands were executed.
This is just a short modification to enable the retry function to show executed command when it failed all of attemptions.