### PR TITLE
Update retry() to show executed command when it failed

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -428,6 +428,8 @@ retry() {
     warn "Failed, retrying...($((i+1)) of ${MAX_TRIES})"
     sleep $((2 * i + 2))
   done
+  local CMD="'$*'"
+  warn "Command $CMD failed."
   false
 }
 


### PR DESCRIPTION
Hi team,

Current install_asm script is hard to debug when it failed because it won't show the actual commands failed.
This is just 2 line modification to show the command executed when it failed. 