### PR TITLE
Update docker file

### DIFF
--- a/asmcli/Dockerfile
+++ b/asmcli/Dockerfile
@@ -1,7 +1,5 @@
 # this is using debian, with a "minimal footprint" install for gcloud
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
-# cloudbuild will mount a volume in this path
-WORKDIR /workspace/asmcli
 # cloudbuild will override this variable:
 ENV SERVICE_ACCOUNT my_sa_email_goes_here
 # cloudbuild will override this variable:
@@ -10,8 +8,13 @@ ENV KEY_FILE path_to_a_key_file_goes_here
 RUN apt-get install google-cloud-sdk-kpt jq kubectl -y
 # install test dependencies
 RUN apt-get install shellcheck posh bc procps openssl yamllint -y
-# copy source files into WORKDIR
-COPY asmcli ./
-COPY tests ./tests/
-COPY Dockerfile ./
+
+# https://docs.bazel.build/versions/master/install-ubuntu.html
+RUN \
+  apt install apt-transport-https curl gnupg -y && \
+  curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg && \
+  mv bazel.gpg /etc/apt/trusted.gpg.d/ && \
+  echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
+  apt update -y && apt install bazel -y
+
 ENTRYPOINT [ "bash" ]

--- a/asmcli/cloudbuild-main.yaml
+++ b/asmcli/cloudbuild-main.yaml
@@ -3,19 +3,24 @@ steps:
   ########
   # SETUP
   ########
-  - name: 'gcr.io/cloud-builders/bazel'
-    entrypoint: 'bazel'
-    args: ['build', 'merge']
-  - name: 'bash'
-    args: ['cp', '${_BAZEL_BIN}/${_SCRIPT_NAME}', asmcli/]
   - name: 'gcr.io/cloud-builders/docker'
-    dir: 'asmcli'
     id: 'build-tester-image'
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}', '.']
+    args: ['build', '-t', 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}', 'asmcli/']
+
   - name: 'gcr.io/cloud-builders/docker'
-    dir: 'asmcli'
     id: 'publish-tester-image'
     args: ['push', 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}']
+
+  - name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
+    entrypoint: '/usr/bin/bazel'
+    args: ['build', 'merge']
+  
+  - name: 'bash'
+    args: ['cp', '${_BAZEL_BIN}/${_SCRIPT_NAME}', asmcli/]
+
+  - name: node
+    entrypoint: npm
+    args: ['install']
 
   - name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
     dir: 'asmcli'
@@ -86,6 +91,11 @@ steps:
   #############
   # FAST TESTS
   #############
+  - name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
+    id: 'unit-test'
+    entrypoint: '/usr/bin/bazel'
+    args: ['test', 'test', "--test_output=streamed"]
+
   - name: 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
     dir: 'asmcli'
     id: 'run-release-debug'


### PR DESCRIPTION
Update the docker file to use the /workspace directly without having to copy. Also, add steps to the cloudbuild yaml to perform `npm install` and run unit tests. 