### PR TITLE
add trustdomain field for hub

### DIFF
--- a/asm/istio/options/hub-meshca.yaml
+++ b/asm/istio/options/hub-meshca.yaml
@@ -40,6 +40,7 @@ spec:
         GKE_CLUSTER_URL: "HUB_IDP_URL" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.hub-idp-url"}
     trustDomainAliases: # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.trustDomainAliases"}
       - "ENVIRON_PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}
+      - "ENVIRON_PROJECT_ID.hub.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}
   values:
     global:
       # Enable SDS


### PR DESCRIPTION
when install for asm 1.10 we need to add hub.id.goog trust domain alias to enable new workload to old workload which uses the hub.id.goog workload pool