### PR TITLE
make --hub_meshca behavior consistent between ASM 1.9 and ASM 1.10 for GKE-on-GCP

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -62,12 +62,6 @@ openAPI:
         setter:
           name: gcloud.project.environProjectNumber
           value: PROJECT_NUMBER
-    io.k8s.cli.setters.gcloud.project.environProjectID:
-      type: string
-      x-k8s-cli:
-        setter:
-          name: gcloud.project.environProjectID
-          value: ENVIRON_PROJECT_ID
     io.k8s.cli.setters.gcloud.compute.location:
       x-k8s-cli:
         setter:
@@ -114,18 +108,18 @@ openAPI:
           name: anthos.servicemesh.canonicalServiceHub
           value: gcr.io/gke-release/asm/canonical-service-controller:1.7.3-asm.6
           isSet: true
-    io.k8s.cli.setters.anthos.servicemesh.hubMembershipID:
-      type: string
-      x-k8s-cli:
-        setter:
-          name: anthos.servicemesh.hubMembershipID
-          value: MEMBERSHIP_ID
     io.k8s.cli.setters.anthos.servicemesh.hub-idp-url:
       type: string
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.hub-idp-url
           value: HUB_IDP_URL
+    io.k8s.cli.setters.anthos.servicemesh.hubTrustDomain:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: anthos.servicemesh.hubTrustDomain
+          value: HUB_TRUST_DOMAIN
     io.k8s.cli.setters.anthos.servicemesh.controlplane.validation-url:
       type: string
       x-k8s-cli:
@@ -211,10 +205,10 @@ openAPI:
       x-k8s-cli:
         substitution:
           name: token-audiences-hub
-          pattern: "istio-ca,ENVIRON_PROJECT_ID.svc.id.goog"
+          pattern: "istio-ca,HUB_TRUST_DOMAIN"
           values:
-          - marker: ENVIRON_PROJECT_ID
-            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'
+          - marker: HUB_TRUST_DOMAIN
+            ref: '#/definitions/io.k8s.cli.setters.anthos.servicemesh.hubTrustDomain'
     io.k8s.cli.substitutions.gke-cluster-url:
       type: string
       x-k8s-cli:
@@ -280,19 +274,10 @@ openAPI:
       x-k8s-cli:
         substitution:
           name: spiffe-bundle-endpoints-hub
-          pattern: ENVIRON_PROJECT_ID.svc.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json
+          pattern: HUB_TRUST_DOMAIN|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json
           values:
-          - marker: ENVIRON_PROJECT_ID
-            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'
-    io.k8s.cli.substitutions.trust-domain-hub:
-      type: string
-      x-k8s-cli:
-        substitution:
-          name: trust-domain-hub
-          pattern: "ENVIRON_PROJECT_ID.svc.id.goog"
-          values:
-          - marker: ENVIRON_PROJECT_ID
-            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectID'
+          - marker: HUB_TRUST_DOMAIN
+            ref: '#/definitions/io.k8s.cli.setters.anthos.servicemesh.hubTrustDomain'
     io.k8s.cli.setters.anthos.servicemesh.external_ca.ca_name:
       x-k8s-cli:
         setter:

--- a/asm/istio/options/hub-meshca.yaml
+++ b/asm/istio/options/hub-meshca.yaml
@@ -23,26 +23,26 @@ spec:
           - name: GKE_CLUSTER_URL
             value: "HUB_IDP_URL" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.hub-idp-url"}
           - name: SPIFFE_BUNDLE_ENDPOINTS
-            value: "ENVIRON_PROJECT_ID.svc.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints-hub"}
+            value: "HUB_TRUST_DOMAIN|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints-hub"}
           - name: ENABLE_STACKDRIVER_MONITORING
             value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
           - name: GCP_METADATA
             value: "PROJECT_ID|PROJECT_NUMBER|asm-cluster|us-central1-c" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-hub-metadata"}
           - name: TOKEN_AUDIENCES
-            value: "istio-ca,ENVIRON_PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.token-audiences-hub"}
+            value: "istio-ca,HUB_TRUST_DOMAIN" # {"$ref":"#/definitions/io.k8s.cli.substitutions.token-audiences-hub"}
           - name: PILOT_ENABLE_CROSS_CLUSTER_WORKLOAD_ENTRY
             value: "true"
   meshConfig:
-    trustDomain: "ENVIRON_PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}
+    trustDomain: "HUB_TRUST_DOMAIN" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.hubTrustDomain"}
     defaultConfig:
       proxyMetadata:
         GCP_METADATA: "PROJECT_ID|PROJECT_NUMBER|asm-cluster|us-central1-c" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-hub-metadata"}
         GKE_CLUSTER_URL: "HUB_IDP_URL" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.hub-idp-url"}
     trustDomainAliases: # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.trustDomainAliases"}
-      - "ENVIRON_PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}
+      - "HUB_TRUST_DOMAIN" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.hubTrustDomain"}
   values:
     global:
       # Enable SDS
       sds:
         token:
-          aud: "ENVIRON_PROJECT_ID.svc.id.goog" # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain-hub"}
+          aud: "HUB_TRUST_DOMAIN" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.hubTrustDomain"}

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -2456,9 +2456,15 @@ configure_package() {
   fi
 
   if [[ "${USE_HUB_WIP}" -eq 1 ]]; then
-    kpt cfg set asm gcloud.project.environProjectID "${ENVIRON_PROJECT_ID}"
-    kpt cfg set asm anthos.servicemesh.hubMembershipID "${HUB_MEMBERSHIP_ID}"
-    kpt cfg set asm anthos.servicemesh.hub-idp-url "${HUB_IDP_URL}"
+    # VM installation uses the latest Hub WIP format
+    if [[ "${USE_VM}" -eq 1 ]]; then
+      kpt cfg set asm anthos.servicemesh.hubTrustDomain "${ENVIRON_PROJECT_ID}.svc.id.goog"
+      kpt cfg set asm anthos.servicemesh.hub-idp-url "${HUB_IDP_URL}"
+    # GKE-on-GCP installation uses legacy Hub WIP format to be consistent with GCP Hub public preview feature
+    else
+      kpt cfg set asm anthos.servicemesh.hubTrustDomain "${ENVIRON_PROJECT_ID}.hub.id.goog"
+      kpt cfg set asm anthos.servicemesh.hub-idp-url "https://gkehub.googleapis.com/projects/${ENVIRON_PROJECT_ID}/locations/global/memberships/${HUB_MEMBERSHIP_ID}"
+    fi
   fi
   if [[ -n "${CA_NAME}" && "${CA}" = "gcp_cas" ]]; then
     kpt cfg set asm anthos.servicemesh.external_ca.ca_name "${CA_NAME}"


### PR DESCRIPTION
For ASM 1.10

- GKE-on-GCP: The Mesh CA with Environ installation option will be kept unchanged, which installs the cluster with the old HUB WIP.  
- VM: new Hub WIP and its IDP will be used. @JimmyCYJ let me know if you want to keep it the same as GKE-on-GCP to use the old Hub WIP. 
- Onprem: new Hub WIP and its IDP will be used. 