### PR TITLE
Adding option revisioned-istio-egressgateway

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -292,6 +292,14 @@ openAPI:
           values:
           - marker: ASM_REV
             ref: '#/definitions/io.k8s.cli.setters.anthos.servicemesh.rev'
+    io.k8s.cli.substitutions.istio-egressgateway-deploy-name:
+      x-k8s-cli:
+        substitution:
+          name: istio-egressgateway-deploy-name
+          pattern: istio-egressgateway-ASM_REV
+          values:
+          - marker: ASM_REV
+            ref: '#/definitions/io.k8s.cli.setters.anthos.servicemesh.rev'
     io.k8s.cli.setters.anthos.servicemesh.custom-ingressgateway-name:
       type: string
       x-k8s-cli:

--- a/asm/istio/options/revisioned-istio-egressgateway.yaml
+++ b/asm/istio/options/revisioned-istio-egressgateway.yaml
@@ -1,0 +1,38 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    egressGateways:
+    # Disable istio-egressgateway to avoid downtime from in-place upgrade
+      - name: istio-egressgateway
+        enabled: false
+      # Workaround to use revision based deployments for istio-egressgateway
+      - name: istio-egressgateway-ASM_REV # {"$ref":"#/definitions/io.k8s.cli.substitutions.istio-egressgateway-deploy-name"}
+        enabled: true
+        k8s:
+          hpaSpec:
+            maxReplicas: 5
+            minReplicas: 2
+          # Rename the service to still use istio-egressgateway
+          overlays:
+            - apiVersion: extensions/v1beta1
+              kind: Service
+              name: istio-egressgateway-ASM_REV # {"$ref":"#/definitions/io.k8s.cli.substitutions.istio-egressgateway-deploy-name"}
+              patches:
+                - path: metadata.name
+                  value: istio-egressgateway


### PR DESCRIPTION
Makes possible to have a revisioned egressgateway the same way there is already a revisioned ingressgateway.

Tested with:
```
./install_asm --version
1.9.5-asm.2+config1
```

Introduces the new option ` --option revisioned-istio-egressgateway`

