### PR TITLE
Download kpt when necessary

### DIFF
--- a/scripts/asm-installer/Dockerfile
+++ b/scripts/asm-installer/Dockerfile
@@ -7,7 +7,7 @@ ENV SERVICE_ACCOUNT my_sa_email_goes_here
 # cloudbuild will override this variable:
 ENV KEY_FILE path_to_a_key_file_goes_here
 # install script dependencies
-RUN apt-get install google-cloud-sdk-kpt jq kubectl ruby-full -y
+RUN apt-get install jq kubectl ruby-full -y
 # install test dependencies
 RUN apt-get install shellcheck posh bc procps openssl yamllint -y
 # copy source files into WORKDIR

--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -157,6 +157,10 @@ main() {
     validate_gcp_resources
   fi
 
+  if needs_asm && needs_kpt; then
+    download_kpt
+  fi
+
   if needs_asm && ! necessary_files_exist; then
     download_asm
   fi
@@ -641,6 +645,13 @@ needs_asm() {
   else
     false
   fi
+}
+
+needs_kpt() {
+  if [[ -z "${AKPT}" ]]; then return; fi
+  KPT_VER="$(kpt version)"
+  if [[ "${KPT_VER:0:1}" != "0" ]]; then return; fi
+  false
 }
 
 add_trust_domain_alias() {
@@ -1411,7 +1422,11 @@ set_up_local_workspace() {
       fatal "${OUTPUT_DIR} exists and is not a directory, please specify another directory."
     fi
   fi
+
+  if [[ -x "${OUTPUT_DIR}/kpt" ]]; then AKPT="$(apath -f "${OUTPUT_DIR}/kpt")"; fi
+
   pushd "$OUTPUT_DIR" > /dev/null
+
 
   if [[ "${KUBECONFIG_SUPPLIED}" -eq 0 ]]; then
     KUBECONFIG="asm_kubeconfig"
@@ -1493,7 +1508,6 @@ $AGCLOUD
 grep
 jq
 $AKUBECTL
-$AKPT
 sed
 tr
 head
@@ -1507,7 +1521,6 @@ EOF
   done <<EOF
 AKUBECTL
 AGCLOUD
-AKPT
 EOF
 
   if [[ "${CUSTOM_CA}" -eq 1 ]]; then
@@ -1533,6 +1546,23 @@ EOF
   if [[ "$(uname -m)" != "x86_64" ]]; then
     fatal "Installation is only supported on x86_64."
   fi
+}
+
+download_kpt() {
+  local OS
+
+  case "$(uname)" in
+    Linux ) OS="linux_amd64";;
+    Darwin) OS="darwin_arm64";;
+    *     ) fatal "$(uname) is not a supported OS.";;
+  esac
+
+  local KPT_TGZ
+  KPT_TGZ="https://github.com/GoogleContainerTools/kpt/releases/download/v0.39.3/kpt_${OS}-0.39.3.tar.gz"
+
+  info "Downloading kpt.."
+  curl -L "${KPT_TGZ}" | tar xz
+  AKPT="$(apath -f kpt)"
 }
 
 download_asm() {

--- a/scripts/asm-installer/tests/run_cli_tests
+++ b/scripts/asm-installer/tests/run_cli_tests
@@ -106,6 +106,9 @@ tar() {
 }
 
 kpt() {
+  if [[ "${1}" = "version" ]]; then
+    echo "1.0.0"
+  fi
   return 0
 }
 
@@ -637,8 +640,8 @@ EOF
 
   WARNED=0
   FATAL_EXITS=0
-  AKPT=""
-  AGCLOUD="gcloud"
+  AKPT="kpt"
+  AGCLOUD=""
   AKUBECTL="kubectl"
   validate_cli_dependencies
   FATAL_EXITS=1
@@ -648,6 +651,18 @@ EOF
     ((++FAILURES))
   else
     echo "validate_cli_dependencies handles compatibility variables: PASS"
+  fi
+  echo "***"
+
+  #################
+  # kpt should be downloaded if the environment version is not 0.x
+  #################
+
+  if ! needs_kpt; then
+    echo "needs_kpt is true when kpt is too new: FAIL"
+    ((++FAILURES))
+  else
+    echo "needs_kpt is true when kpt is too new: PASS"
   fi
   echo "***"
 


### PR DESCRIPTION
With the upcoming 1.0 release of `kpt`, we need to make sure that users get a version that works with the config here. This will download `kpt` if it's necessary for the action taken (install vs print config etc.) and one of the following:
 * the system version is too new
 * there isn't a `kpt` binary in the specified OUTPUT_DIR already