### PR TITLE
Fix token audience for managed CNI.

### DIFF
--- a/asm/istio/options/cni-managed.yaml
+++ b/asm/istio/options/cni-managed.yaml
@@ -447,4 +447,4 @@ spec:
                   path: istio-token
                   expirationSeconds: 43200
                   # yamllint disable-line rule:line-length
-                  audience: "PROJECT_ID.svc.id.goog"  # {"$ref":"#/definitions/io.k8s.cli.substitutions.token-audiences"}
+                  audience: "PROJECT_ID.svc.id.goog"  # {"$ref":"#/definitions/io.k8s.cli.substitutions.trust-domain"}


### PR DESCRIPTION
Same change as https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/pull/809, but for asmcli.