### PR TITLE
Use New Hub WIP as default for GCP

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1245,12 +1245,6 @@ validate_dependencies() {
     exit_if_apis_not_enabled
   fi
 
-  if can_register_cluster && is_gcp; then
-    register_cluster
-  elif should_validate && [[ "${USE_HUB_WIP}" -eq 1 || "${USE_VM}" -eq 1 ]]; then
-    exit_if_cluster_unregistered
-  fi
-
   if is_gcp; then
     if can_modify_gcp_components; then
       enable_workload_identity
@@ -1265,6 +1259,12 @@ validate_dependencies() {
         exit_if_service_mesh_feature_not_enabled
       fi
     fi
+  fi
+
+  if can_register_cluster && is_gcp; then
+    register_cluster
+  elif should_validate && [[ "${USE_HUB_WIP}" -eq 1 || "${USE_VM}" -eq 1 ]]; then
+    exit_if_cluster_unregistered
   fi
 
   get_project_number
@@ -1327,6 +1327,14 @@ validate_hub() {
 
   if ! is_managed && [[ "${USE_VM}" -eq 1 && "${USE_HUB_WIP}" -eq 0 ]]; then
     fatal "Hub Workload Identity Pool is required to add VM workloads. Run the script with the -o hub-meshca option."
+  fi
+
+  if ! is_managed && [[ "${CA}" == "mesh_ca" && "${USE_HUB_WIP}" -eq 0 ]] && ( can_register_cluster && is_gcp || is_cluster_registered ) ; then
+    info "Fleet workload identity pool is used as default for Mesh CA. "
+    context_set-option "USE_HUB_WIP" 1
+    local OPTIONAL_OVERLAY; OPTIONAL_OVERLAY="$(context_get-option "OPTIONAL_OVERLAY")"
+    OPTIONAL_OVERLAY="hub-meshca,${OPTIONAL_OVERLAY}"
+    context_set-option "OPTIONAL_OVERLAY" "${OPTIONAL_OVERLAY}"
   fi
 }
 
@@ -1896,13 +1904,13 @@ configure_in_cluster_control_plane() {
 
 init_meshconfig() {
   local USE_HUB_WIP; USE_HUB_WIP="$(context_get-option "USE_HUB_WIP")"
-  local HUB_MEMBERSHIP_ID; HUB_MEMBERSHIP_ID="$(context_get-option "HUB_MEMBERSHIP_ID")"
   local FLEET_ID; FLEET_ID="$(context_get-option "FLEET_ID")"
   local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
 
   info "Initializing meshconfig API..."
   if [[ "${USE_HUB_WIP}" -eq 1 ]]; then
     populate_fleet_info
+    local HUB_MEMBERSHIP_ID; HUB_MEMBERSHIP_ID="$(context_get-option "HUB_MEMBERSHIP_ID")"
     info "Cluster has Membership ID ${HUB_MEMBERSHIP_ID} in the Hub of project ${FLEET_ID}"
     if [[ "${FLEET_ID}" != "${PROJECT_ID}" ]]; then
       info "Skip initializing meshconfig API as the Hub is not hosted in the project ${PROJECT_ID}"
@@ -2308,14 +2316,11 @@ can_modify_gcp_components() {
 
 can_register_cluster() {
   local ENABLE_ALL; ENABLE_ALL="$(context_get-option "ENABLE_ALL")"
-  local USE_VM; USE_VM="$(context_get-option "USE_VM")"
-  local USE_HUB_WIP; USE_HUB_WIP="$(context_get-option "USE_HUB_WIP")"
   local ENABLE_REGISTRATION; ENABLE_REGISTRATION="$(context_get-option "ENABLE_REGISTRATION")"
 
   if ! can_modify_at_all; then false; return; fi
 
-  if [[ "${ENABLE_ALL}" -eq 1 && ("${USE_VM}" -eq 1 || "${USE_HUB_WIP}" -eq 1) ]] \
-    || [[ "${ENABLE_REGISTRATION}" -eq 1 ]]; then
+  if [[ "${ENABLE_ALL}" -eq 1 ]] || [[ "${ENABLE_REGISTRATION}" -eq 1 ]]; then
     true
   else
     false
@@ -2417,7 +2422,6 @@ configure_package() {
   local CLUSTER_LOCATION; CLUSTER_LOCATION="$(context_get-option "CLUSTER_LOCATION")"
   local USE_HUB_WIP; USE_HUB_WIP="$(context_get-option "USE_HUB_WIP")"
   local FLEET_ID; FLEET_ID="$(context_get-option "FLEET_ID")"
-  local HUB_MEMBERSHIP_ID; HUB_MEMBERSHIP_ID="$(context_get-option "HUB_MEMBERSHIP_ID")"
   local CA; CA="$(context_get-option "CA")"
   local CA_NAME; CA_NAME="$(context_get-option "CA_NAME")"
   local USE_VM; USE_VM="$(context_get-option "USE_VM")"
@@ -2452,15 +2456,8 @@ configure_package() {
   fi
 
   if [[ "${USE_HUB_WIP}" -eq 1 ]]; then
-    # VM installation uses the latest Hub WIP format
-    if [[ "${USE_VM}" -eq 1 ]]; then
-      kpt cfg set asm anthos.servicemesh.hubTrustDomain "${FLEET_ID}.svc.id.goog"
-      kpt cfg set asm anthos.servicemesh.hub-idp-url "${HUB_IDP_URL}"
-    # GKE-on-GCP installation uses legacy Hub WIP format to be consistent with GCP Hub public preview feature
-    else
-      kpt cfg set asm anthos.servicemesh.hubTrustDomain "${FLEET_ID}.hub.id.goog"
-      kpt cfg set asm anthos.servicemesh.hub-idp-url "https://gkehub.googleapis.com/projects/${FLEET_ID}/locations/global/memberships/${HUB_MEMBERSHIP_ID}"
-    fi
+    kpt cfg set asm anthos.servicemesh.hubTrustDomain "${FLEET_ID}.svc.id.goog"
+    kpt cfg set asm anthos.servicemesh.hub-idp-url "${HUB_IDP_URL}"
   fi
   if [[ -n "${CA_NAME}" && "${CA}" = "gcp_cas" ]]; then
     kpt cfg set asm anthos.servicemesh.external_ca.ca_name "${CA_NAME}"
@@ -3037,6 +3034,7 @@ parse_args() {
         OPTIONAL_OVERLAY="${2},${OPTIONAL_OVERLAY}"
         context_set-option "OPTIONAL_OVERLAY" "${OPTIONAL_OVERLAY}"
         if [[ "${2}" == "hub-meshca" ]]; then
+          info "Fleet workload identity pool is used as default for Mesh CA. No need to specify hub-meshca option."
           context_set-option "USE_HUB_WIP" 1
         fi
         if [[ "${2}" == "vm" ]]; then

--- a/asmcli/components/control-plane/in-cluster.sh
+++ b/asmcli/components/control-plane/in-cluster.sh
@@ -27,13 +27,13 @@ configure_in_cluster_control_plane() {
 
 init_meshconfig() {
   local USE_HUB_WIP; USE_HUB_WIP="$(context_get-option "USE_HUB_WIP")"
-  local HUB_MEMBERSHIP_ID; HUB_MEMBERSHIP_ID="$(context_get-option "HUB_MEMBERSHIP_ID")"
   local FLEET_ID; FLEET_ID="$(context_get-option "FLEET_ID")"
   local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
 
   info "Initializing meshconfig API..."
   if [[ "${USE_HUB_WIP}" -eq 1 ]]; then
     populate_fleet_info
+    local HUB_MEMBERSHIP_ID; HUB_MEMBERSHIP_ID="$(context_get-option "HUB_MEMBERSHIP_ID")"
     info "Cluster has Membership ID ${HUB_MEMBERSHIP_ID} in the Hub of project ${FLEET_ID}"
     if [[ "${FLEET_ID}" != "${PROJECT_ID}" ]]; then
       info "Skip initializing meshconfig API as the Hub is not hosted in the project ${PROJECT_ID}"

--- a/asmcli/lib/checks.sh
+++ b/asmcli/lib/checks.sh
@@ -270,14 +270,11 @@ can_modify_gcp_components() {
 
 can_register_cluster() {
   local ENABLE_ALL; ENABLE_ALL="$(context_get-option "ENABLE_ALL")"
-  local USE_VM; USE_VM="$(context_get-option "USE_VM")"
-  local USE_HUB_WIP; USE_HUB_WIP="$(context_get-option "USE_HUB_WIP")"
   local ENABLE_REGISTRATION; ENABLE_REGISTRATION="$(context_get-option "ENABLE_REGISTRATION")"
 
   if ! can_modify_at_all; then false; return; fi
 
-  if [[ "${ENABLE_ALL}" -eq 1 && ("${USE_VM}" -eq 1 || "${USE_HUB_WIP}" -eq 1) ]] \
-    || [[ "${ENABLE_REGISTRATION}" -eq 1 ]]; then
+  if [[ "${ENABLE_ALL}" -eq 1 ]] || [[ "${ENABLE_REGISTRATION}" -eq 1 ]]; then
     true
   else
     false

--- a/asmcli/lib/config.sh
+++ b/asmcli/lib/config.sh
@@ -4,7 +4,6 @@ configure_package() {
   local CLUSTER_LOCATION; CLUSTER_LOCATION="$(context_get-option "CLUSTER_LOCATION")"
   local USE_HUB_WIP; USE_HUB_WIP="$(context_get-option "USE_HUB_WIP")"
   local FLEET_ID; FLEET_ID="$(context_get-option "FLEET_ID")"
-  local HUB_MEMBERSHIP_ID; HUB_MEMBERSHIP_ID="$(context_get-option "HUB_MEMBERSHIP_ID")"
   local CA; CA="$(context_get-option "CA")"
   local CA_NAME; CA_NAME="$(context_get-option "CA_NAME")"
   local USE_VM; USE_VM="$(context_get-option "USE_VM")"
@@ -39,15 +38,8 @@ configure_package() {
   fi
 
   if [[ "${USE_HUB_WIP}" -eq 1 ]]; then
-    # VM installation uses the latest Hub WIP format
-    if [[ "${USE_VM}" -eq 1 ]]; then
-      kpt cfg set asm anthos.servicemesh.hubTrustDomain "${FLEET_ID}.svc.id.goog"
-      kpt cfg set asm anthos.servicemesh.hub-idp-url "${HUB_IDP_URL}"
-    # GKE-on-GCP installation uses legacy Hub WIP format to be consistent with GCP Hub public preview feature
-    else
-      kpt cfg set asm anthos.servicemesh.hubTrustDomain "${FLEET_ID}.hub.id.goog"
-      kpt cfg set asm anthos.servicemesh.hub-idp-url "https://gkehub.googleapis.com/projects/${FLEET_ID}/locations/global/memberships/${HUB_MEMBERSHIP_ID}"
-    fi
+    kpt cfg set asm anthos.servicemesh.hubTrustDomain "${FLEET_ID}.svc.id.goog"
+    kpt cfg set asm anthos.servicemesh.hub-idp-url "${HUB_IDP_URL}"
   fi
   if [[ -n "${CA_NAME}" && "${CA}" = "gcp_cas" ]]; then
     kpt cfg set asm anthos.servicemesh.external_ca.ca_name "${CA_NAME}"

--- a/asmcli/lib/parse.sh
+++ b/asmcli/lib/parse.sh
@@ -70,6 +70,7 @@ parse_args() {
         OPTIONAL_OVERLAY="${2},${OPTIONAL_OVERLAY}"
         context_set-option "OPTIONAL_OVERLAY" "${OPTIONAL_OVERLAY}"
         if [[ "${2}" == "hub-meshca" ]]; then
+          info "Fleet workload identity pool is used as default for Mesh CA. No need to specify hub-meshca option."
           context_set-option "USE_HUB_WIP" 1
         fi
         if [[ "${2}" == "vm" ]]; then

--- a/asmcli/tests/main_test.bats
+++ b/asmcli/tests/main_test.bats
@@ -251,7 +251,7 @@ teardown() {
   fi
 }
 
-@test "MAIN: --enable-all should grant all permissions but shouldn't register to environ when unnecessary" {
+@test "MAIN: --enable-all should grant all permissions and register to environ when necessary" {
   context_init
 
   local CMD
@@ -263,7 +263,7 @@ teardown() {
 
   parse_args ${CMD}
 
-  if can_register_cluster; then
+  if ! can_register_cluster; then
     exit 1
   fi
 }


### PR DESCRIPTION
This PR will use new Hub WIP as default option for unmanaged GCP with MeshCA. 
1. The command to install ASM with MeshCA with asmcli is the following. 
```
./asmcli install \
  --project_id $PROJECT_ID \
  --cluster_name $CLUSTER_NAME \
  --cluster_location $CLUSTER_LOCATION \
  --enable_all
```
In this case, we will help user register the cluster  and use Hub WIP. 

2. If the user specified `hub-meshca` option, populate a message to tell user that `hub-meshca` is not needed. 

3. When user does not specify enable_all or enable_registration, and the cluster has not been registered into Hub before the installation, user is allowed to install ASM with GKE WIP. 