### PR TITLE
Add kubeconfig (GKE only) support to create-mesh subcommand.

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -151,18 +151,46 @@ parse_cluster_args() {
   fi
 
   while [[ $# != 0 ]]; do
-    local CLUSTER; CLUSTER="${1}"
-    context_append "clustersInfo" "${CLUSTER//\// }"
+    if [ -e "$1" ]; then
+      local KCF; KCF="${1}"
+      context_append "kubeconfigFiles" "${KCF}"
+    else
+      local CLUSTER; CLUSTER="${1}"
+      context_append "clustersInfo" "${CLUSTER//\// }"
+    fi
     shift 1
   done
 }
 
 validate_cluster_args() {
+  local KCF
+  local PROJECT_ID
+  local CLUSTER_LOCATION
+  local CLUSTER_NAME
+  local CTX_CLUSTER
+  local GKE_CLUSTER_URI
+
   # validate fleet id is valid
   get_project_number
 
+  # flatten any kubeconfig files into cluster P/L/C
+  while read -r KCF; do
+    # check a default context exists
+    CONTEXT="$(kubectl --kubeconfig ${KCF} config current-context)"
+    if [[ -z "${CONTEXT}" ]]; then
+      fatal "Missing current-context in ${KCF}. Please set a current-context in the KUBECONFIG"
+    else
+      # use the default context to add to clusterInfo list
+      IFS="_" read -r _ PROJECT_ID CLUSTER_LOCATION CLUSTER_NAME <<EOF
+${CONTEXT}
+EOF
+      context_append "clustersInfo" "${PROJECT_ID} ${CLUSTER_LOCATION} ${CLUSTER_NAME}"
+    fi
+  done <<EOF
+$(context_list "kubeconfigFiles")
+EOF
+
   # validate clusters are valid
-  local PROJECT_ID CLUSTER_LOCATION CLUSTER_NAME CTX_CLUSTER GKE_CLUSTER_URI
   while read -r PROJECT_ID CLUSTER_LOCATION CLUSTER_NAME; do
     context_set-option "PROJECT_ID" "${PROJECT_ID}"
     context_set-option "CLUSTER_LOCATION" "${CLUSTER_LOCATION}"
@@ -2114,7 +2142,8 @@ context_init() {
   "kubectlFiles": [],
   "clustersInfo": [],
   "clusterRegistrations": [],
-  "clusterContexts": []
+  "clusterContexts": [],
+  "kubeconfigFiles": []
 }
 EOF
 )
@@ -3790,6 +3819,7 @@ validate_args() {
   local WI_ENABLED; WI_ENABLED="$(context_get-option "WI_ENABLED")"
   local CONTEXT; CONTEXT="$(context_get-option "CONTEXT")"
   local KUBECONFIG_SUPPLIED; KUBECONFIG_SUPPLIED="$(context_get-option "KUBECONFIG_SUPPLIED")"
+  local KCF; KCF="$(context_get-option "KUBECONFIG")"
 
   if [[ -z "${CA}" ]]; then
     CA="mesh_ca"
@@ -3866,7 +3896,7 @@ EOF
   if [[ "${KUBECONFIG_SUPPLIED}" -eq 1 && -z "${CONTEXT}" ]]; then
     # set CONTEXT to current-context in the KUBECONFIG
     # or fail-fast if current-context doesn't exist
-    CONTEXT="$(kubectl config current-context)"
+    CONTEXT="$(kubectl --kubeconfig ${KCF} config current-context)"
     if [[ -z "${CONTEXT}" ]]; then
       MISSING_ARGS=1
       warn "Missing current-context in the KUBECONFIG. Please provide context with --context flag or set a current-context in the KUBECONFIG"

--- a/asmcli/commands/create-mesh.sh
+++ b/asmcli/commands/create-mesh.sh
@@ -22,23 +22,46 @@ parse_cluster_args() {
   fi
 
   while [[ $# != 0 ]]; do
-    if [[ "$1" =~ .+/.+/.+ ]]; then
-      local CLUSTER; CLUSTER="${1}"
-      context_append "clustersInfo" "${CLUSTER//\// }"
-    else
+    if [ -e "$1" ]; then
       local KCF; KCF="${1}"
       context_append "kubeconfigFiles" "${KCF}"
+    else
+      local CLUSTER; CLUSTER="${1}"
+      context_append "clustersInfo" "${CLUSTER//\// }"
     fi
     shift 1
   done
 }
 
 validate_cluster_args() {
+  local KCF
+  local PROJECT_ID
+  local CLUSTER_LOCATION
+  local CLUSTER_NAME
+  local CTX_CLUSTER
+  local GKE_CLUSTER_URI
+
   # validate fleet id is valid
   get_project_number
 
+  # flatten any kubeconfig files into cluster P/L/C
+  while read -r KCF; do
+    # check a default context exists
+    CONTEXT="$(kubectl --kubeconfig ${KCF} config current-context)"
+    if [[ -z "${CONTEXT}" ]]; then
+      fatal "Missing current-context in ${KCF}. Please set a current-context in the KUBECONFIG"
+    else
+      # use the default context to add to clusterInfo list
+      IFS="_" read -r _ PROJECT_ID CLUSTER_LOCATION CLUSTER_NAME <<EOF
+${CONTEXT}
+EOF
+      context_append "clustersInfo" "${PROJECT_ID} ${CLUSTER_LOCATION} ${CLUSTER_NAME}"
+    fi
+  done <<EOF
+$(context_list "kubeconfigFiles")
+EOF
+
   # validate clusters are valid
-  local PROJECT_ID CLUSTER_LOCATION CLUSTER_NAME CTX_CLUSTER GKE_CLUSTER_URI
   while read -r PROJECT_ID CLUSTER_LOCATION CLUSTER_NAME; do
     context_set-option "PROJECT_ID" "${PROJECT_ID}"
     context_set-option "CLUSTER_LOCATION" "${CLUSTER_LOCATION}"

--- a/asmcli/commands/create-mesh.sh
+++ b/asmcli/commands/create-mesh.sh
@@ -22,8 +22,13 @@ parse_cluster_args() {
   fi
 
   while [[ $# != 0 ]]; do
-    local CLUSTER; CLUSTER="${1}"
-    context_append "clustersInfo" "${CLUSTER//\// }"
+    if [[ "$1" =~ .+/.+/.+ ]]; then
+      local CLUSTER; CLUSTER="${1}"
+      context_append "clustersInfo" "${CLUSTER//\// }"
+    else
+      local KCF; KCF="${1}"
+      context_append "kubeconfigFiles" "${KCF}"
+    fi
     shift 1
   done
 }

--- a/asmcli/lib/context.sh
+++ b/asmcli/lib/context.sh
@@ -57,7 +57,8 @@ context_init() {
   "kubectlFiles": [],
   "clustersInfo": [],
   "clusterRegistrations": [],
-  "clusterContexts": []
+  "clusterContexts": [],
+  "kubeconfigFiles": []
 }
 EOF
 )

--- a/asmcli/lib/validate.sh
+++ b/asmcli/lib/validate.sh
@@ -492,6 +492,7 @@ validate_args() {
   local WI_ENABLED; WI_ENABLED="$(context_get-option "WI_ENABLED")"
   local CONTEXT; CONTEXT="$(context_get-option "CONTEXT")"
   local KUBECONFIG_SUPPLIED; KUBECONFIG_SUPPLIED="$(context_get-option "KUBECONFIG_SUPPLIED")"
+  local KCF; KCF="$(context_get-option "KUBECONFIG")"
 
   if [[ -z "${CA}" ]]; then
     CA="mesh_ca"
@@ -568,7 +569,7 @@ EOF
   if [[ "${KUBECONFIG_SUPPLIED}" -eq 1 && -z "${CONTEXT}" ]]; then
     # set CONTEXT to current-context in the KUBECONFIG
     # or fail-fast if current-context doesn't exist
-    CONTEXT="$(kubectl config current-context)"
+    CONTEXT="$(kubectl --kubeconfig ${KCF} config current-context)"
     if [[ -z "${CONTEXT}" ]]; then
       MISSING_ARGS=1
       warn "Missing current-context in the KUBECONFIG. Please provide context with --context flag or set a current-context in the KUBECONFIG"


### PR DESCRIPTION
The subcommand can accept N kubeconfig files, each of which is expected
to contain a default context that will be the ONLY context used. The UX
for N clusters would be to supply N differennt files, each of which will
have a default context set to the corresponding target cluster.