### PR TITLE
deprecate --only-validate and fix parse bug 

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -2617,11 +2617,6 @@ get_auth_token() {
   echo "${TOKEN}"
 }
 parse_args() {
-  if [[ "${*}" = '' ]]; then
-    usage_short >&2
-    exit 2
-  fi
-
   # shellcheck disable=SC2064
   trap "$(shopt -p nocasematch)" RETURN
   shopt -s nocasematch
@@ -2847,11 +2842,6 @@ parse_args() {
 }
 
 x_parse_install_args() {
-  if [[ "${*}" = '' ]]; then
-    x_usage >&2
-    exit 2
-  fi
-
   # shellcheck disable=SC2064
   trap "$(shopt -p nocasematch)" RETURN
   shopt -s nocasematch
@@ -4187,7 +4177,7 @@ EOF
     "${ENABLE_GCP_IAM_ROLES}" -eq 1 || "${ENABLE_GCP_COMPONENTS}" -eq 1 || \
     "${ENABLE_REGISTRATION}" -eq 1  || "${ENABLE_NAMESPACE_CREATION}" -eq 1 ]]; then
     if [[ "${ONLY_VALIDATE}" -eq 1 ]]; then
-      fatal "The only_validate flag cannot be used with any --enable* flag"
+      fatal "validation cannot be run with any --enable* flag"
     fi
   elif only_enable; then
     fatal "You must specify at least one --enable* flag with --only_enable"
@@ -4361,7 +4351,7 @@ EOF
     "${ENABLE_GCP_IAM_ROLES}" -eq 1 || "${ENABLE_GCP_COMPONENTS}" -eq 1 || \
     "${ENABLE_REGISTRATION}" -eq 1  || "${ENABLE_NAMESPACE_CREATION}" -eq 1 ]]; then
     if [[ "${ONLY_VALIDATE}" -eq 1 ]]; then
-      fatal "The only_validate flag cannot be used with any --enable* flag"
+      fatal "validation cannot be run with any --enable* flag"
     fi
   elif only_enable; then
     fatal "You must specify at least one --enable* flag with --only_enable"

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -2761,7 +2761,7 @@ parse_args() {
         shift 1
         ;;
       --only_validate | --only-validate)
-        warn "As of version 1.11 the --only_validate flag is deprecated and will be ignored."
+        warn "In version 1.11 the --only_validate flag will be deprecated and ignored."
         warn "Please use \"asmcli valdiate\" instead."
         context_set-option "ONLY_VALIDATE" 1
         shift 1

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -967,6 +967,7 @@ FLAGS:
                                       support various features.
   -v|--verbose                        Print commands before and after execution.
      --dry_run                        Print commands, but don't execute them.
+     --only_validate                  Run validation, but don't install.
      --only_enable                    Perform the specified steps to set up the
                                       current user/cluster but don't install
                                       anything.
@@ -2765,9 +2766,9 @@ parse_args() {
         shift 1
         ;;
       --only_validate | --only-validate)
-        warn "As of version 1.10 the --only_validate flag is deprecated and will be ignored."
+        warn "As of version 1.11 the --only_validate flag is deprecated and will be ignored."
         warn "Please use \"asmcli valdiate\" instead."
-        exit
+        context_set-option "ONLY_VALIDATE" 1
         shift 1
         ;;
       --only_enable | --only-enable)

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -967,7 +967,6 @@ FLAGS:
                                       support various features.
   -v|--verbose                        Print commands before and after execution.
      --dry_run                        Print commands, but don't execute them.
-     --only_validate                  Run validation, but don't install.
      --only_enable                    Perform the specified steps to set up the
                                       current user/cluster but don't install
                                       anything.
@@ -2766,7 +2765,9 @@ parse_args() {
         shift 1
         ;;
       --only_validate | --only-validate)
-        context_set-option "ONLY_VALIDATE" 1
+        warn "As of version 1.10 the --only_validate flag is deprecated and will be ignored."
+        warn "Please use \"asmcli valdiate\" instead."
+        exit
         shift 1
         ;;
       --only_enable | --only-enable)

--- a/asmcli/commands/help.sh
+++ b/asmcli/commands/help.sh
@@ -163,7 +163,6 @@ FLAGS:
                                       support various features.
   -v|--verbose                        Print commands before and after execution.
      --dry_run                        Print commands, but don't execute them.
-     --only_validate                  Run validation, but don't install.
      --only_enable                    Perform the specified steps to set up the
                                       current user/cluster but don't install
                                       anything.

--- a/asmcli/commands/help.sh
+++ b/asmcli/commands/help.sh
@@ -163,6 +163,7 @@ FLAGS:
                                       support various features.
   -v|--verbose                        Print commands before and after execution.
      --dry_run                        Print commands, but don't execute them.
+     --only_validate                  Run validation, but don't install.
      --only_enable                    Perform the specified steps to set up the
                                       current user/cluster but don't install
                                       anything.

--- a/asmcli/lib/parse.sh
+++ b/asmcli/lib/parse.sh
@@ -148,9 +148,9 @@ parse_args() {
         shift 1
         ;;
       --only_validate | --only-validate)
-        warn "As of version 1.10 the --only_validate flag is deprecated and will be ignored."
+        warn "As of version 1.11 the --only_validate flag is deprecated and will be ignored."
         warn "Please use \"asmcli valdiate\" instead."
-        exit
+        context_set-option "ONLY_VALIDATE" 1
         shift 1
         ;;
       --only_enable | --only-enable)

--- a/asmcli/lib/parse.sh
+++ b/asmcli/lib/parse.sh
@@ -148,7 +148,9 @@ parse_args() {
         shift 1
         ;;
       --only_validate | --only-validate)
-        context_set-option "ONLY_VALIDATE" 1
+        warn "As of version 1.10 the --only_validate flag is deprecated and will be ignored."
+        warn "Please use \"asmcli valdiate\" instead."
+        exit
         shift 1
         ;;
       --only_enable | --only-enable)

--- a/asmcli/lib/parse.sh
+++ b/asmcli/lib/parse.sh
@@ -1,9 +1,4 @@
 parse_args() {
-  if [[ "${*}" = '' ]]; then
-    usage_short >&2
-    exit 2
-  fi
-
   # shellcheck disable=SC2064
   trap "$(shopt -p nocasematch)" RETURN
   shopt -s nocasematch
@@ -229,11 +224,6 @@ parse_args() {
 }
 
 x_parse_install_args() {
-  if [[ "${*}" = '' ]]; then
-    x_usage >&2
-    exit 2
-  fi
-
   # shellcheck disable=SC2064
   trap "$(shopt -p nocasematch)" RETURN
   shopt -s nocasematch

--- a/asmcli/lib/parse.sh
+++ b/asmcli/lib/parse.sh
@@ -143,7 +143,7 @@ parse_args() {
         shift 1
         ;;
       --only_validate | --only-validate)
-        warn "As of version 1.11 the --only_validate flag is deprecated and will be ignored."
+        warn "In version 1.11 the --only_validate flag will be deprecated and ignored."
         warn "Please use \"asmcli valdiate\" instead."
         context_set-option "ONLY_VALIDATE" 1
         shift 1

--- a/asmcli/lib/validate.sh
+++ b/asmcli/lib/validate.sh
@@ -651,7 +651,7 @@ EOF
     "${ENABLE_GCP_IAM_ROLES}" -eq 1 || "${ENABLE_GCP_COMPONENTS}" -eq 1 || \
     "${ENABLE_REGISTRATION}" -eq 1  || "${ENABLE_NAMESPACE_CREATION}" -eq 1 ]]; then
     if [[ "${ONLY_VALIDATE}" -eq 1 ]]; then
-      fatal "The only_validate flag cannot be used with any --enable* flag"
+      fatal "validation cannot be run with any --enable* flag"
     fi
   elif only_enable; then
     fatal "You must specify at least one --enable* flag with --only_enable"
@@ -825,7 +825,7 @@ EOF
     "${ENABLE_GCP_IAM_ROLES}" -eq 1 || "${ENABLE_GCP_COMPONENTS}" -eq 1 || \
     "${ENABLE_REGISTRATION}" -eq 1  || "${ENABLE_NAMESPACE_CREATION}" -eq 1 ]]; then
     if [[ "${ONLY_VALIDATE}" -eq 1 ]]; then
-      fatal "The only_validate flag cannot be used with any --enable* flag"
+      fatal "validation cannot be run with any --enable* flag"
     fi
   elif only_enable; then
     fatal "You must specify at least one --enable* flag with --only_enable"


### PR DESCRIPTION
this PR does
1. show deprecation message for `--only-validate`
2. fix the parsing bug where user gets no meaningful info after the parsing is delegated to each subcommand.