### PR TITLE
Private CA GA integration changes

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -1106,10 +1106,6 @@ validate_args() {
       fatal "Citadel is not supported with managed control plane."
     fi
 
-    if [[ "${CA}" == "gcp_cas" ]]; then
-      fatal "Google Certificate Authority Service integration is not supported with managed control plane."
-    fi
-
     if [[ "${CUSTOM_CA}" -eq 1 ]]; then
       fatal "Specifying a custom CA with managed control plane is not supported."
     fi
@@ -1312,7 +1308,7 @@ validate_revision_label() {
 
 validate_gcp_cas_args() {
   local CA_NAME_TEMPLATE
-  CA_NAME_TEMPLATE="projects/project_name/locations/ca_region/certificateAuthorities/ca_name"
+  CA_NAME_TEMPLATE="projects/project_name/locations/ca_region/caPools/ca_pool"
   readonly CA_NAME_TEMPLATE
 
   if [[ -z ${CA_NAME} ]]; then
@@ -1901,9 +1897,10 @@ is_meshca_installed() {
 }
 
 is_gcp_cas_installed() {
-  local INSTALLED_CA; INSTALLED_CA="$(kubectl -n istio-system get pod -l istio=istiod \
-    -o jsonpath='{.items[].spec.containers[].env[?(@.name=="EXTERNAL_CA")].value}')"
-  [[ "${INSTALLED_CA}" = "ISTIOD_RA_CAS_API" ]] && return 0
+  local INSTALLED_CA_PROVIDER
+  INSTALLED_CA_PROVIDER="$(kubectl -n istio-system get pod -l istio=ingressgateway \
+    -o jsonpath='{.items[].spec.containers[].env[?(@.name=="CA_PROVIDER")].value}')"
+  [[ "${INSTALLED_CA_PROVIDER}" = "GoogleCAS" ]] && return 0
 }
 
 bind_user_to_iam_policy(){
@@ -2589,21 +2586,19 @@ install_secrets() {
 
 init_gcp_cas() {
 
-  local ISTIOD_SERVICE_ACCOUNT; ISTIOD_SERVICE_ACCOUNT="istiod-${REVISION_LABEL}"
-  if [[ "${_CI_NO_REVISION}" -ne 0 ]]; then
-    ISTIOD_SERVICE_ACCOUNT="istiod"
-  fi
-
-  local WORKLOAD_IDENTITY; WORKLOAD_IDENTITY="${PROJECT_ID}.svc.id.goog[istio-system/${ISTIOD_SERVICE_ACCOUNT}]"
-  local NAME; NAME=$(echo "${CA_NAME}" | cut -f6 -d/)
+  local WORKLOAD_IDENTITY; WORKLOAD_IDENTITY="${PROJECT_ID}.svc.id.goog[-/-]"
   local CA_LOCATION; CA_LOCATION=$(echo "${CA_NAME}" | cut -f4 -d/)
-  local CA_PROJECT; CA_PROJECT=$(echo "${CA_NAME}" | cut -f2 -d/)
 
-  retry 3 gcloud beta privateca subordinates add-iam-policy-binding "${NAME}" \
+  retry 3 gcloud privateca pools add-iam-policy-binding "${CA_NAME}" \
     --location "${CA_LOCATION}" \
-    --project "${CA_PROJECT}" \
     --member "serviceAccount:${WORKLOAD_IDENTITY}" \
-    --role "roles/privateca.certificateManager"
+    --role "roles/privateca.workloadCertificateRequester"
+
+  retry 3 gcloud privateca pools add-iam-policy-binding "${CA_NAME}" \
+    --location "${CA_LOCATION}" \
+    --member "serviceAccount:${WORKLOAD_IDENTITY}" \
+    --role "roles/privateca.auditor"
+
 }
 
 does_istiod_exist(){


### PR DESCRIPTION
Amending ASM installation scripts for GA integration with Google [CAS](https://cloud.google.com/certificate-authority-service)

* Changed the environments supported (Managed Control Plane is also supported)

* Changed the IAM privileges required for ASM workloads to request certificates and trustAnchors from CAS

Main purpose of making these changes here is to backport these changes if needed into release-1.10-asm