### PR TITLE
Add telemetry to validating webhook

### DIFF
--- a/asm/istio/options/managed-control-plane-webhooks.yaml
+++ b/asm/istio/options/managed-control-plane-webhooks.yaml
@@ -33,6 +33,7 @@ webhooks:
         apiGroups:
           - security.istio.io
           - networking.istio.io
+          - telemetry.istio.io
         apiVersions:
           - "*"
         resources:


### PR DESCRIPTION
This should be merged to 1.11 branch. It can be merged to 1.10, but does nothing. It MUST not be merged to 1.9.