### PR TITLE
move validate_hub after configure_kubectl

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1373,6 +1373,7 @@ validate_subcommand() {
 validate() {
   local ONLY_VALIDATE; ONLY_VALIDATE="$(context_get-option "ONLY_VALIDATE")"
 
+  validate_hub
   validate_dependencies
   validate_control_plane
 
@@ -4392,8 +4393,6 @@ EOF
   context_set-option "CUSTOM_OVERLAY" "${CUSTOM_OVERLAY}"
 
   WORKLOAD_POOL="${PROJECT_ID}.svc.id.goog"; readonly WORKLOAD_POOL
-
-  validate_hub
 }
 
 arg_required() {

--- a/asmcli/commands/validate.sh
+++ b/asmcli/commands/validate.sh
@@ -12,6 +12,7 @@ validate_subcommand() {
 validate() {
   local ONLY_VALIDATE; ONLY_VALIDATE="$(context_get-option "ONLY_VALIDATE")"
 
+  validate_hub
   validate_dependencies
   validate_control_plane
 

--- a/asmcli/lib/validate.sh
+++ b/asmcli/lib/validate.sh
@@ -703,8 +703,6 @@ EOF
   context_set-option "CUSTOM_OVERLAY" "${CUSTOM_OVERLAY}"
 
   WORKLOAD_POOL="${PROJECT_ID}.svc.id.goog"; readonly WORKLOAD_POOL
-
-  validate_hub
 }
 
 arg_required() {


### PR DESCRIPTION
currently `validate_hub` comes before `prepare_environment`, which causes the fleet info to not be populated correctly since `kubectl` is not configured. 