### PR TITLE
Increase resource limits for both containers

### DIFF
--- a/asm/canonical-service/controller.yaml
+++ b/asm/canonical-service/controller.yaml
@@ -310,6 +310,13 @@ spec:
         - --v=10
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
         name: kube-rbac-proxy
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
         ports:
         - containerPort: 8443
           name: https
@@ -323,7 +330,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 100Mi
+            memory: 300Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/issues/877
We are seeing an increasing number of OOMKilled issues.  Increasing the memory limits has fixed the issue for customers, and should be defined by default.