### PR TITLE
fix the curl quotation

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1663,7 +1663,7 @@ init_meshconfig() {
       init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
     fi
   else
-    init_meshconfig_curl "''" "${PROJECT_ID}"
+    init_meshconfig_curl '' "${PROJECT_ID}"
   fi
 }
 validate_managed_control_plane() {

--- a/asmcli/components/control-plane/in-cluster.sh
+++ b/asmcli/components/control-plane/in-cluster.sh
@@ -42,6 +42,6 @@ init_meshconfig() {
       init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
     fi
   else
-    init_meshconfig_curl "''" "${PROJECT_ID}"
+    init_meshconfig_curl '' "${PROJECT_ID}"
   fi
 }


### PR DESCRIPTION
the tests do not cover in #884 since `USE_HUB_WIP` is default to be true. Manually tested with 
```
_CI_ASM_PKG_LOCATION=asm-staging-images _CI_ASM_KPT_BRANCH=main USE_HUB_WIP=0 ./asmcli/asmcli install --kubeconfig ~/.kube/config -v -e --only-enable
```

and it worked. 