### PR TITLE
fix the revision label bug

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -2987,6 +2987,7 @@ x_parse_install_args() {
   trap "$(shopt -p nocasematch)" RETURN
   shopt -s nocasematch
 
+  REVISION_LABEL="$(context_get-option "REVISION_LABEL")"
   while [[ $# != 0 ]]; do
     case "${1}" in
       -l | --cluster_location | --cluster-location)

--- a/asmcli/lib/parse.sh
+++ b/asmcli/lib/parse.sh
@@ -237,6 +237,7 @@ x_parse_install_args() {
   trap "$(shopt -p nocasematch)" RETURN
   shopt -s nocasematch
 
+  REVISION_LABEL="$(context_get-option "REVISION_LABEL")"
   while [[ $# != 0 ]]; do
     case "${1}" in
       -l | --cluster_location | --cluster-location)


### PR DESCRIPTION
`asmcli x install` does not properly populate the revision label global. 