### PR TITLE
Add experimental mcp-migrate-check

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -335,6 +335,10 @@ experimental_subcommand() {
       shift 1
       x_install_subcommand "${@}"
       ;;
+    mcp-migrate-check)
+      shift 1
+      x_mcp_migrate_check "${@}"
+      ;;
     *)
       x_help_subcommand "${@}"
       ;;
@@ -357,6 +361,10 @@ SUBCOMMANDS:
                                       instead of client-side tools
   vm                                  Functions to configure a mesh to
                                       allow external VM workloads.
+  mcp-migrate-check                   Checks IstioOperator config for
+                                      compatibility with a Google managed
+                                      control plane and generates new config
+                                      where possible.
 EOF
 }
 x_install_subcommand() {
@@ -394,6 +402,66 @@ x_configure_package() {
   if [[ -n "${_CI_ASM_IMAGE_TAG}" ]]; then
     kpt cfg set asm anthos.servicemesh.tag "${_CI_ASM_IMAGE_TAG}"
   fi
+}
+x_mcp_migrate_check() {
+  x_parse_mcp_migrate_args "${@}"
+  x_download_istioctl_tarball
+  context_set-option "VERBOSE" 1
+
+  PARAMS=""
+  for yaml_file in $(context_list "istioctlFiles"); do
+    PARAMS="${PARAMS} -f ${yaml_file}"
+  done
+
+  # shellcheck disable=SC2086
+  x_istioctl asm mcp-migrate ${PARAMS}
+}
+
+x_parse_mcp_migrate_args() {
+  # shellcheck disable=SC2064
+  trap "$(shopt -p nocasematch)" RETURN
+  shopt -s nocasematch
+
+  while [[ $# != 0 ]]; do
+    case "${1}" in
+      -f)
+        arg_required "${@}"
+        if [[ ! -f "${2}" ]]; then
+          fatal "Couldn't find yaml file ${2}."
+        fi
+        context_append "istioctlFiles" "${2}"
+        shift 2
+        ;;
+      *)
+        fatal "Unknown option ${1}"
+        ;;
+    esac
+  done
+}
+
+x_download_istioctl_tarball() {
+  case "$(uname)" in
+    Linux ) OS="linux-amd64";;
+    Darwin) OS="osx";;
+    *     ) fatal "$(uname) is not a supported OS.";;
+  esac
+
+  info "Downloading ASM.."
+  local TARBALL; TARBALL="istio-${RELEASE}-${OS}.tar.gz"
+  if [[ -z "${_CI_ASM_PKG_LOCATION}" ]]; then
+    curl -L "https://storage.googleapis.com/gke-release/asm/${TARBALL}" \
+      | tar xz
+  else
+    local TOKEN; TOKEN="$(retry 2 gcloud auth print-access-token)"
+    run_command curl -L "https://storage.googleapis.com/${_CI_ASM_PKG_LOCATION}/asm/${TARBALL}" \
+      --header @- <<EOF | tar xz
+Authorization: Bearer ${TOKEN}
+EOF
+  fi
+}
+
+x_istioctl() {
+  run_command "$(istioctl_path)" "${@}"
 }
 x_validate_dependencies() {
   local FLEET_ID; FLEET_ID="$(context_get-option "FLEET_ID")"

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -408,6 +408,7 @@ x_mcp_migrate_check() {
   x_download_istioctl_tarball
   context_set-option "VERBOSE" 1
 
+  local PARAMS
   PARAMS=""
   for yaml_file in $(context_list "istioctlFiles"); do
     PARAMS="${PARAMS} -f ${yaml_file}"
@@ -440,6 +441,7 @@ x_parse_mcp_migrate_args() {
 }
 
 x_download_istioctl_tarball() {
+  local OS
   case "$(uname)" in
     Linux ) OS="linux-amd64";;
     Darwin) OS="osx";;

--- a/asmcli/commands/experimental.sh
+++ b/asmcli/commands/experimental.sh
@@ -13,6 +13,10 @@ experimental_subcommand() {
       shift 1
       x_install_subcommand "${@}"
       ;;
+    mcp-migrate-check)
+      shift 1
+      x_mcp_migrate_check "${@}"
+      ;;
     *)
       x_help_subcommand "${@}"
       ;;

--- a/asmcli/commands/experimental/help.sh
+++ b/asmcli/commands/experimental/help.sh
@@ -15,5 +15,9 @@ SUBCOMMANDS:
                                       instead of client-side tools
   vm                                  Functions to configure a mesh to
                                       allow external VM workloads.
+  mcp-migrate-check                   Checks IstioOperator config for
+                                      compatibility with a Google managed
+                                      control plane and generates new config
+                                      where possible.
 EOF
 }

--- a/asmcli/commands/experimental/mcp-migrate-check.sh
+++ b/asmcli/commands/experimental/mcp-migrate-check.sh
@@ -3,6 +3,7 @@ x_mcp_migrate_check() {
   x_download_istioctl_tarball
   context_set-option "VERBOSE" 1
 
+  local PARAMS
   PARAMS=""
   for yaml_file in $(context_list "istioctlFiles"); do
     PARAMS="${PARAMS} -f ${yaml_file}"
@@ -35,6 +36,7 @@ x_parse_mcp_migrate_args() {
 }
 
 x_download_istioctl_tarball() {
+  local OS
   case "$(uname)" in
     Linux ) OS="linux-amd64";;
     Darwin) OS="osx";;

--- a/asmcli/commands/experimental/mcp-migrate-check.sh
+++ b/asmcli/commands/experimental/mcp-migrate-check.sh
@@ -1,0 +1,60 @@
+x_mcp_migrate_check() {
+  x_parse_mcp_migrate_args "${@}"
+  x_download_istioctl_tarball
+  context_set-option "VERBOSE" 1
+
+  PARAMS=""
+  for yaml_file in $(context_list "istioctlFiles"); do
+    PARAMS="${PARAMS} -f ${yaml_file}"
+  done
+
+  # shellcheck disable=SC2086
+  x_istioctl asm mcp-migrate ${PARAMS}
+}
+
+x_parse_mcp_migrate_args() {
+  # shellcheck disable=SC2064
+  trap "$(shopt -p nocasematch)" RETURN
+  shopt -s nocasematch
+
+  while [[ $# != 0 ]]; do
+    case "${1}" in
+      -f)
+        arg_required "${@}"
+        if [[ ! -f "${2}" ]]; then
+          fatal "Couldn't find yaml file ${2}."
+        fi
+        context_append "istioctlFiles" "${2}"
+        shift 2
+        ;;
+      *)
+        fatal "Unknown option ${1}"
+        ;;
+    esac
+  done
+}
+
+x_download_istioctl_tarball() {
+  case "$(uname)" in
+    Linux ) OS="linux-amd64";;
+    Darwin) OS="osx";;
+    *     ) fatal "$(uname) is not a supported OS.";;
+  esac
+
+  info "Downloading ASM.."
+  local TARBALL; TARBALL="istio-${RELEASE}-${OS}.tar.gz"
+  if [[ -z "${_CI_ASM_PKG_LOCATION}" ]]; then
+    curl -L "https://storage.googleapis.com/gke-release/asm/${TARBALL}" \
+      | tar xz
+  else
+    local TOKEN; TOKEN="$(retry 2 gcloud auth print-access-token)"
+    run_command curl -L "https://storage.googleapis.com/${_CI_ASM_PKG_LOCATION}/asm/${TARBALL}" \
+      --header @- <<EOF | tar xz
+Authorization: Bearer ${TOKEN}
+EOF
+  fi
+}
+
+x_istioctl() {
+  run_command "$(istioctl_path)" "${@}"
+}


### PR DESCRIPTION
Tested locally with this output:

```
./asmcli/asmcli x mcp-migrate-check -f test 
asmcli: Downloading ASM..
Generating equivalent configuration for Anthos Service Mesh managed control plane...

Migrating MeshConfig settings...
✔ Wrote MeshConfig to asm-generated-configs/meshconfig.yaml.

Migrating gateway deployments...

Checking configuration compatibility...
! Found unsupported configurations:
    Components.Base: not configurable in managed control plane
    Components.Pilot: not configurable in managed control plane
    Hub=gcr.io/gke-release/asm: not configurable in managed control plane
    Tag=1.10.4-asm.6: not configurable in managed control plane

Actions required to migrate:
! Found potentially unsupported configurations; review warnings above before proceeding
- Found custom mesh configuration settings. To apply these settings to ASM managed control plane, run: `kubectl apply -f 'asm-generated-configs/meshconfig.yaml'`

TIP: steps recommending `kubectl apply` to be run should be integrated into your CI/CD pipeline, if applicable.
```