### PR TITLE
fix initialize and runIstiod

### DIFF
--- a/scripts/asm-installer/install_asm
+++ b/scripts/asm-installer/install_asm
@@ -2123,9 +2123,11 @@ init_meshconfig() {
     populate_environ_info
     info "Cluster has Membership ID ${HUB_MEMBERSHIP_ID} in the Hub of project ${ENVIRON_PROJECT_ID}"
     # initialize replaces the existing Workload Identity Pools in the IAM binding, so we need to support both Hub and GKE Workload Identity Pools
-    local POST_DATA; POST_DATA='{"workloadIdentityPools":["'${ENVIRON_PROJECT_ID}'.hub.id.goog","'${ENVIRON_PROJECT_ID}'.svc.id.goog"]}'
+    local POST_DATA
+    POST_DATA='{"workloadIdentityPools":["'${PROJECT_ID}'.hub.id.goog","'${PROJECT_ID}'.svc.id.goog"]}'
     init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
-    if [[ "${ENVIRON_PROJECT_ID}" != "${PROJECT_ID}" ]]; then
+    if [[ -n "${ENVIRON_PROJECT_ID}" && "${ENVIRON_PROJECT_ID}" != "${PROJECT_ID}" ]]; then
+      POST_DATA='{"workloadIdentityPools":["'${ENVIRON_PROJECT_ID}'.hub.id.goog","'${ENVIRON_PROJECT_ID}'.svc.id.goog"]}'
       init_meshconfig_curl "${POST_DATA}" "${ENVIRON_PROJECT_ID}"
     fi
   else
@@ -2136,13 +2138,10 @@ init_meshconfig() {
 init_meshconfig_managed() {
   info "Initializing meshconfig managed API..."
   local POST_DATA
-  if [[ "${USE_HUB_WIP}" -eq 1 && -n "${ENVIRON_PROJECT_ID}" ]]; then
-    POST_DATA='{"workloadIdentityPools":["'${ENVIRON_PROJECT_ID}'.hub.id.goog","'${ENVIRON_PROJECT_ID}'.svc.id.goog"], "prepare_istiod": true}'
-  else
-    POST_DATA='{"workloadIdentityPools":["'${PROJECT_ID}'.hub.id.goog","'${PROJECT_ID}'.svc.id.goog"], "prepare_istiod": true}'
-  fi
+  POST_DATA='{"workloadIdentityPools":["'${PROJECT_ID}'.hub.id.goog","'${PROJECT_ID}'.svc.id.goog"], "prepare_istiod": true}'
   init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
-  if [[ "${ENVIRON_PROJECT_ID}" != "${PROJECT_ID}" ]]; then
+  if [[ "${USE_HUB_WIP}" -eq 1 && -n "${ENVIRON_PROJECT_ID}" && "${ENVIRON_PROJECT_ID}" != "${PROJECT_ID}" ]]; then
+    POST_DATA='{"workloadIdentityPools":["'${ENVIRON_PROJECT_ID}'.hub.id.goog","'${ENVIRON_PROJECT_ID}'.svc.id.goog"]}'
     init_meshconfig_curl "${POST_DATA}" "${ENVIRON_PROJECT_ID}"
   fi
 }
@@ -2743,17 +2742,19 @@ data:
 EOF
   fi
 
-  local CR_IMAGE_JSON; CR_IMAGE_JSON="";
+  local POST_DATA; POST_DATA="{}";
   if [[ -n "${_CI_CLOUDRUN_IMAGE_HUB}" ]]; then
-    CR_IMAGE_JSON=$(cat <<EOF
-{"image": "${_CI_CLOUDRUN_IMAGE_HUB}:${_CI_CLOUDRUN_IMAGE_TAG}"}
-EOF
-)
+    POST_DATA="$(echo "${POST_DATA}" | jq -r --arg IMAGE "${_CI_CLOUDRUN_IMAGE_HUB}:${_CI_CLOUDRUN_IMAGE_TAG}" '. + {image: $IMAGE}')"
   fi
+
+  if [[ -n "${ENVIRON_PROJECT_ID}" && "${ENVIRON_PROJECT_ID}" != "${PROJECT_ID}" ]]; then
+    POST_DATA="$(echo "${POST_DATA}" | jq -r --arg MEMBERSHIP "${HUB_IDP_URL/*projects/projects}" '. + {membership: $MEMBERSHIP}')"
+  fi
+
   info "Provisioning managed control plane..."
   retry 2 run curl --request POST \
     "https://meshconfig.googleapis.com/v1alpha1/projects/${PROJECT_ID}/locations/${CLUSTER_LOCATION}/clusters/${CLUSTER_NAME}:runIstiod" \
-    --data "${CR_IMAGE_JSON}" \
+    --data "${POST_DATA}" \
     --header "X-Server-Timeout: 600" \
     --header "Content-Type: application/json" \
     -K <(auth_header "$(get_auth_token)")


### PR DESCRIPTION
Current requirements:
1. `initialize` should send `requesting_project` trust domains. 
2. the call with the extra `FLEET_ID` should not have `prepare_istiod: true`. 
3. send membership info to `runIstiod` if `FLEET_ID != PROJECT_ID`

Below is the local test output.  cluster `cluster-2` belongs to`zhengzhe-anthos-test` (`PROJECT_ID`), but is registered to `zhengzhe-test-project` (`FLEET_ID`)

**UNMANAGED INITIALIZE**
```
2021-08-26T18:57:20.671024 install_asm: Initializing meshconfig API...
2021-08-26T18:57:20.700936 install_asm: Cluster has Membership ID cluster-2 in the Hub of project zhengzhe-test-project
2021-08-26T18:57:20.729978 install_asm: Running: 'curl --request POST --fail --data {"workloadIdentityPools":["zhengzhe-anthos-test.hub.id.goog","zhengzhe-anthos-test.svc.id.goog"]} -o /dev/null https://meshconfig.googleapis.com/v1alpha1/projects/zhengzhe-anthos-test:initialize --header X-Server-Timeout: 600 --header Content-Type: application/json -K /dev/fd/63'
2021-08-26T18:57:20.733117 install_asm: Running: '/usr/local/google/home/zhengzhey/google-cloud-sdk/bin/gcloud --project=zhengzhe-anthos-test auth print-access-token'
2021-08-26T18:57:20.760917 install_asm: -------------
2021-08-26T18:57:20.761602 install_asm: -------------
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   100    0     3  100    97      5    189 --:--:-- --:--:-- --:--:--   195
2021-08-26T18:57:22.034522 install_asm: Running: 'curl --request POST --fail --data {"workloadIdentityPools":["zhengzhe-test-project.hub.id.goog","zhengzhe-test-project.svc.id.goog"]} -o /dev/null https://meshconfig.googleapis.com/v1alpha1/projects/zhengzhe-test-project:initialize --header X-Server-Timeout: 600 --header Content-Type: application/json -K /dev/fd/63'
2021-08-26T18:57:22.038026 install_asm: Running: '/usr/local/google/home/zhengzhey/google-cloud-sdk/bin/gcloud --project=zhengzhe-anthos-test auth print-access-token'
2021-08-26T18:57:22.061372 install_asm: -------------
2021-08-26T18:57:22.064515 install_asm: -------------
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   102    0     3  100    99     14    475 --:--:-- --:--:-- --:--:--   490
```
**MANAGED INITIALIZE** (2 calls, the extra call should not have `prepare_istiod` field)

```
2021-08-26T19:05:19.658396 install_asm: Initializing meshconfig managed API...
2021-08-26T19:05:19.688020 install_asm: Running: 'curl --request POST --fail --data {"workloadIdentityPools":["zhengzhe-anthos-test.hub.id.goog","zhengzhe-anthos-test.svc.id.goog"], "prepare_istiod": true} -o /dev/null https://meshconfig.googleapis.com/v1alpha1/projects/zhengzhe-anthos-test:initialize --header X-Server-Timeout: 600 --header Content-Type: application/json -K /dev/fd/63'
2021-08-26T19:05:19.690367 install_asm: Running: '/usr/local/google/home/zhengzhey/google-cloud-sdk/bin/gcloud --project=zhengzhe-anthos-test auth print-access-token'
2021-08-26T19:05:19.716044 install_asm: -------------
2021-08-26T19:05:19.718306 install_asm: -------------
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   216    0    95  100   121    238    304 --:--:-- --:--:-- --:--:--   542
2021-08-26T19:05:20.962462 install_asm: Running: 'curl --request POST --fail --data {"workloadIdentityPools":["zhengzhe-test-project.hub.id.goog","zhengzhe-test-project.svc.id.goog"]} -o /dev/null https://meshconfig.googleapis.com/v1alpha1/projects/zhengzhe-test-project:initialize --header X-Server-Timeout: 600 --header Content-Type: application/json -K /dev/fd/63'
2021-08-26T19:05:20.965879 install_asm: Running: '/usr/local/google/home/zhengzhey/google-cloud-sdk/bin/gcloud --project=zhengzhe-anthos-test auth print-access-token'
2021-08-26T19:05:20.992707 install_asm: -------------
2021-08-26T19:05:20.996138 install_asm: -------------
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   102    0     3  100    99     20    682 --:--:-- --:--:-- --:--:--   703
```

**MANAGED RUNISTIOD** (with membership info)
```
2021-08-25T21:23:14.050794 install_asm: Provisioning managed control plane...
2021-08-25T21:23:14.082848 install_asm: Running: 'curl --request POST https://meshconfig.googleapis.com/v1alpha1/projects/zhengzhe-anthos-test/locations/us-central1-c/clusters/cluster-2:runIstiod --data {
2021-08-25T21:23:14.082934   "membership": "projects/zhengzhe-test-project/locations/global/memberships/cluster-2"
2021-08-25T21:23:14.082948 } --header X-Server-Timeout: 600 --header Content-Type: application/json -K /dev/fd/63'
2021-08-25T21:23:14.083959 install_asm: Running: '/usr/local/google/home/zhengzhey/google-cloud-sdk/bin/gcloud --project=zhengzhe-anthos-test auth print-access-token'
2021-08-25T21:23:14.111565 install_asm: -------------
2021-08-25T21:23:14.111726 install_asm: -------------
{}
```