### PR TITLE
Update istio-egressgateway.yaml

### DIFF
--- a/samples/gateways/istio-egressgateway.yaml
+++ b/samples/gateways/istio-egressgateway.yaml
@@ -16,13 +16,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: istio-egressgateway-service-account
-  namespace: GATEWAY_NAMESPACE
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-egressgateway
-  namespace: GATEWAY_NAMESPACE
 spec:
   selector:
     matchLabels:
@@ -41,7 +39,6 @@ spec:
       labels:
         app: istio-egressgateway
         istio: egressgateway
-        istio.io/rev: REVISION
     spec:
       affinity:
         nodeAffinity:
@@ -135,7 +132,6 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: istio-egressgateway
-  namespace: GATEWAY_NAMESPACE
 spec:
   minAvailable: 1
   selector:
@@ -147,7 +143,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: istio-egressgateway-sds
-  namespace: GATEWAY_NAMESPACE
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -157,7 +152,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: istio-egressgateway-sds
-  namespace: GATEWAY_NAMESPACE
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -170,7 +164,6 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: istio-egressgateway
-  namespace: GATEWAY_NAMESPACE
 spec:
   maxReplicas: 5
   metrics:
@@ -188,7 +181,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: istio-egressgateway
-  namespace: GATEWAY_NAMESPACE
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
Remove the namespace and the revision. This simplifies the steps in the docs. We'll specify the namespace  in the `kubectl apply` command.