### PR TITLE
fix initialize and prepare_istiod

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1768,9 +1768,11 @@ init_meshconfig() {
     local HUB_MEMBERSHIP_ID; HUB_MEMBERSHIP_ID="$(context_get-option "HUB_MEMBERSHIP_ID")"
     info "Cluster has Membership ID ${HUB_MEMBERSHIP_ID} in the Hub of project ${FLEET_ID}"
     # initialize replaces the existing Workload Identity Pools in the IAM binding, so we need to support both Hub and GKE Workload Identity Pools
-    local POST_DATA; POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
+    local POST_DATA
+    POST_DATA='{"workloadIdentityPools":["'${PROJECT_ID}'.hub.id.goog","'${PROJECT_ID}'.svc.id.goog"]}'
     init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
     if [[ "${FLEET_ID}" != "${PROJECT_ID}" ]]; then
+      POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
       init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
     fi
   else
@@ -1886,9 +1888,11 @@ init_meshconfig_managed() {
   local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
 
   info "Initializing meshconfig managed API..."
-  local POST_DATA; POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"], "prepare_istiod": true}'
+  local POST_DATA
+  POST_DATA='{"workloadIdentityPools":["'${PROJECT_ID}'.hub.id.goog","'${PROJECT_ID}'.svc.id.goog"], "prepare_istiod": true}'
   init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
   if [[ "${FLEET_ID}" != "${PROJECT_ID}" ]]; then
+    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
     init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
   fi
 }

--- a/asmcli/components/control-plane/in-cluster.sh
+++ b/asmcli/components/control-plane/in-cluster.sh
@@ -36,9 +36,11 @@ init_meshconfig() {
     local HUB_MEMBERSHIP_ID; HUB_MEMBERSHIP_ID="$(context_get-option "HUB_MEMBERSHIP_ID")"
     info "Cluster has Membership ID ${HUB_MEMBERSHIP_ID} in the Hub of project ${FLEET_ID}"
     # initialize replaces the existing Workload Identity Pools in the IAM binding, so we need to support both Hub and GKE Workload Identity Pools
-    local POST_DATA; POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
+    local POST_DATA
+    POST_DATA='{"workloadIdentityPools":["'${PROJECT_ID}'.hub.id.goog","'${PROJECT_ID}'.svc.id.goog"]}'
     init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
     if [[ "${FLEET_ID}" != "${PROJECT_ID}" ]]; then
+      POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
       init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
     fi
   else

--- a/asmcli/components/control-plane/managed.sh
+++ b/asmcli/components/control-plane/managed.sh
@@ -107,9 +107,11 @@ init_meshconfig_managed() {
   local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
 
   info "Initializing meshconfig managed API..."
-  local POST_DATA; POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"], "prepare_istiod": true}'
+  local POST_DATA
+  POST_DATA='{"workloadIdentityPools":["'${PROJECT_ID}'.hub.id.goog","'${PROJECT_ID}'.svc.id.goog"], "prepare_istiod": true}'
   init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
   if [[ "${FLEET_ID}" != "${PROJECT_ID}" ]]; then
+    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
     init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
   fi
 }


### PR DESCRIPTION
Related to #905, do the same to `asmcli`
Requirements:
1. initialize should send requesting_project trust domains.
2. the call with the extra FLEET_ID should not have prepare_istiod: true.

Below is the local test output. cluster cluster-2 belongs tozhengzhe-anthos-test (PROJECT_ID), but is registered to zhengzhe-test-project (FLEET_ID)

**UNMANAGED INITIALIZE**
```
2021-08-27T21:07:18.111838 asmcli: Initializing meshconfig API...
2021-08-27T21:07:18.326875 asmcli: Cluster has Membership ID cluster-2 in the Hub of project zhengzhe-test-project
2021-08-27T21:07:18.468392 asmcli: Running: 'curl --request POST --fail --data {"workloadIdentityPools":["zhengzhe-anthos-test.hub.id.goog","zhengzhe-anthos-test.svc.id.goog"]} -o /dev/null https://meshconfig.googleapis.com/v1alpha1/projects/zhengzhe-anthos-test:initialize --header X-Server-Timeout: 600 --header Content-Type: application/json -K /dev/fd/63'
2021-08-27T21:07:18.511313 asmcli: Running: '/usr/local/google/home/zhengzhey/google-cloud-sdk/bin/gcloud --project=zhengzhe-anthos-test auth print-access-token'
2021-08-27T21:07:18.532424 asmcli: -------------
2021-08-27T21:07:18.577603 asmcli: -------------
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   100    0     3  100    97      5    164 --:--:-- --:--:-- --:--:--   169
2021-08-27T21:07:20.088330 asmcli: Running: 'curl --request POST --fail --data {"workloadIdentityPools":["zhengzhe-test-project.hub.id.goog","zhengzhe-test-project.svc.id.goog"]} -o /dev/null https://meshconfig.googleapis.com/v1alpha1/projects/zhengzhe-test-project:initialize --header X-Server-Timeout: 600 --header Content-Type: application/json -K /dev/fd/63'
2021-08-27T21:07:20.130201 asmcli: Running: '/usr/local/google/home/zhengzhey/google-cloud-sdk/bin/gcloud --project=zhengzhe-anthos-test auth print-access-token'
2021-08-27T21:07:20.158407 asmcli: -------------
2021-08-27T21:07:20.197692 asmcli: -------------
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   102    0     3  100    99      5    173 --:--:-- --:--:-- --:--:--   178
```

**MANAGED INITIALIZE** (2 calls, the extra call should not have prepare_istiod field)
```
2021-08-27T21:10:10.932550 asmcli: Initializing meshconfig managed API...
2021-08-27T21:10:11.076566 asmcli: Running: 'curl --request POST --fail --data {"workloadIdentityPools":["zhengzhe-anthos-test.hub.id.goog","zhengzhe-anthos-test.svc.id.goog"], "prepare_istiod": true} -o /dev/null https://meshconfig.googleapis.com/v1alpha1/projects/zhengzhe-anthos-test:initialize --header X-Server-Timeout: 600 --header Content-Type: application/json -K /dev/fd/63'
2021-08-27T21:10:11.115057 asmcli: Running: '/usr/local/google/home/zhengzhey/google-cloud-sdk/bin/gcloud --project=zhengzhe-anthos-test auth print-access-token'
2021-08-27T21:10:11.142500 asmcli: -------------
2021-08-27T21:10:11.181600 asmcli: -------------
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   216    0    95  100   121    472    601 --:--:-- --:--:-- --:--:--  1074
2021-08-27T21:10:12.291672 asmcli: Running: 'curl --request POST --fail --data {"workloadIdentityPools":["zhengzhe-test-project.hub.id.goog","zhengzhe-test-project.svc.id.goog"]} -o /dev/null https://meshconfig.googleapis.com/v1alpha1/projects/zhengzhe-test-project:initialize --header X-Server-Timeout: 600 --header Content-Type: application/json -K /dev/fd/63'
2021-08-27T21:10:12.330253 asmcli: Running: '/usr/local/google/home/zhengzhey/google-cloud-sdk/bin/gcloud --project=zhengzhe-anthos-test auth print-access-token'
2021-08-27T21:10:12.356286 asmcli: -------------
2021-08-27T21:10:12.395058 asmcli: -------------
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   102    0     3  100    99     17    565 --:--:-- --:--:-- --:--:--   579
```
