### PR TITLE
Update CNI autopilot overlay.

### DIFF
--- a/asm/istio/options/cni-gke-autopilot.yaml
+++ b/asm/istio/options/cni-gke-autopilot.yaml
@@ -26,8 +26,8 @@ spec:
       podAnnotations:
         autopilot.gke.io/no-connect: "true"
       env:
-      - name: CNI_ENABLE_REINSTALL  # disable reinstall to make migration easy
-        value: "false"
+        - name: CNI_ENABLE_REINSTALL  # disable reinstall to make migration easy
+          value: "false"
       cniBinDir: /home/kubernetes/bin
       excludeNamespaces:
         - istio-system

--- a/asm/istio/options/cni-gke-autopilot.yaml
+++ b/asm/istio/options/cni-gke-autopilot.yaml
@@ -23,6 +23,11 @@ spec:
       namespace: istio-system
   values:
     cni:
+      podAnnotations:
+        autopilot.gke.io/no-connect: "true"
+      env:
+      - name: CNI_ENABLE_REINSTALL  # disable reinstall to make migration easy
+        value: "false"
       cniBinDir: /home/kubernetes/bin
       excludeNamespaces:
         - istio-system


### PR DESCRIPTION
* Add no-connect annotation, which blocks exec into the CNI pod.
* Disable CNI reinstall. This will make migration easy in the future.