### PR TITLE
Fix the ASM CAS installation

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1295,15 +1295,19 @@ install_private_ca() {
 
   local WORKLOAD_IDENTITY; WORKLOAD_IDENTITY="${WORKLOAD_POOL}:/allAuthenticatedUsers/"
   local CA_LOCATION; CA_LOCATION=$(echo "${CA_NAME}" | cut -f4 -d/)
+  local CA_POOL; CA_POOL=$(echo "${CA_NAME}" | cut -f6 -d/)
+  local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
 
-  retry 3 gcloud privateca pools add-iam-policy-binding "${CA_NAME}" \
+  retry 3 gcloud privateca pools add-iam-policy-binding "${CA_POOL}" \
+    --project "${PROJECT_ID}" \
     --location "${CA_LOCATION}" \
     --member "group:${WORKLOAD_IDENTITY}" \
     --role "roles/privateca.workloadCertificateRequester"
 
-  retry 3 gcloud privateca pools add-iam-policy-binding "${CA_NAME}" \
+  retry 3 gcloud privateca pools add-iam-policy-binding "${CA_POOL}" \
+    --project "${PROJECT_ID}" \
     --location "${CA_LOCATION}" \
-    --member "serviceAccount:${WORKLOAD_IDENTITY}" \
+    --member "group:${WORKLOAD_IDENTITY}" \
     --role "roles/privateca.auditor"
 }
 

--- a/asmcli/commands/install.sh
+++ b/asmcli/commands/install.sh
@@ -72,15 +72,19 @@ install_private_ca() {
 
   local WORKLOAD_IDENTITY; WORKLOAD_IDENTITY="${WORKLOAD_POOL}:/allAuthenticatedUsers/"
   local CA_LOCATION; CA_LOCATION=$(echo "${CA_NAME}" | cut -f4 -d/)
+  local CA_POOL; CA_POOL=$(echo "${CA_NAME}" | cut -f6 -d/)
+  local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
 
-  retry 3 gcloud privateca pools add-iam-policy-binding "${CA_NAME}" \
+  retry 3 gcloud privateca pools add-iam-policy-binding "${CA_POOL}" \
+    --project "${PROJECT_ID}" \
     --location "${CA_LOCATION}" \
     --member "group:${WORKLOAD_IDENTITY}" \
     --role "roles/privateca.workloadCertificateRequester"
 
-  retry 3 gcloud privateca pools add-iam-policy-binding "${CA_NAME}" \
+  retry 3 gcloud privateca pools add-iam-policy-binding "${CA_POOL}" \
+    --project "${PROJECT_ID}" \
     --location "${CA_LOCATION}" \
-    --member "serviceAccount:${WORKLOAD_IDENTITY}" \
+    --member "group:${WORKLOAD_IDENTITY}" \
     --role "roles/privateca.auditor"
 }
 


### PR DESCRIPTION
This PR fixes the following problems of ASM CAS installation:
- add-iam-policy-binding should use the CA pool as its argument, instead of the CA name (in the form of "projects/project_name/locations/ca_region/caPools/ca_pool").
- The role "roles/privateca.auditor" should be added to the member "group:${WORKLOAD_IDENTITY}", instead of "serviceAccount:${WORKLOAD_IDENTITY}". When the role "roles/privateca.auditor" is added to "serviceAccount:${WORKLOAD_IDENTITY}", an error occurs.
- The --project is needed to specify the project ID.
