### PR TITLE
fix the bug where it should be fleet_id

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -233,7 +233,7 @@ EOF
       context_append "clusterRegistrations" "${CTX_CLUSTER} ${GKE_CLUSTER_URI}"
     else
       exit_if_cluster_registered_to_another_fleet "${PROJECT_ID}" "${CLUSTER_LOCATION}" "${CLUSTER_NAME}"
-      warn "Cluster ${CLUSTER_NAME} is already registered with project ${PROJECT_ID}. Skipping."
+      warn "Cluster ${CLUSTER_NAME} is already registered with fleet ${FLEET_ID}. Skipping."
     fi
     context_append "clusterContexts" "${CTX_CLUSTER}"
   done <<EOF
@@ -256,13 +256,14 @@ add_one_to_mesh() {
   local GKE_CLUSTER_URI; GKE_CLUSTER_URI="${2}"
   local PROJECT_ID CLUSTER_LOCATION CLUSTER_NAME MEMBERSHIP_NAME
   IFS='_' read -r _ PROJECT_ID CLUSTER_LOCATION CLUSTER_NAME < <(echo "$CTX_CLUSTER")
+  local FLEET_ID; FLEET_ID="$(context_get-option "FLEET_ID")"
 
   MEMBERSHIP_NAME="$(generate_membership_name "${PROJECT_ID}" "${CLUSTER_LOCATION}" "${CLUSTER_NAME}")"
 
   info "Registering the cluster ${PROJECT_ID}/${CLUSTER_LOCATION}/${CLUSTER_NAME} as ${MEMBERSHIP_NAME}..."
 
   retry 2 gcloud container hub memberships register "${MEMBERSHIP_NAME}" \
-    --project="${PROJECT_ID}" \
+    --project="${FLEET_ID}" \
     --gke-uri="${GKE_CLUSTER_URI}" \
     --enable-workload-identity
 }

--- a/asmcli/commands/create-mesh.sh
+++ b/asmcli/commands/create-mesh.sh
@@ -102,7 +102,7 @@ EOF
       context_append "clusterRegistrations" "${CTX_CLUSTER} ${GKE_CLUSTER_URI}"
     else
       exit_if_cluster_registered_to_another_fleet "${PROJECT_ID}" "${CLUSTER_LOCATION}" "${CLUSTER_NAME}"
-      warn "Cluster ${CLUSTER_NAME} is already registered with project ${PROJECT_ID}. Skipping."
+      warn "Cluster ${CLUSTER_NAME} is already registered with fleet ${FLEET_ID}. Skipping."
     fi
     context_append "clusterContexts" "${CTX_CLUSTER}"
   done <<EOF
@@ -125,13 +125,14 @@ add_one_to_mesh() {
   local GKE_CLUSTER_URI; GKE_CLUSTER_URI="${2}"
   local PROJECT_ID CLUSTER_LOCATION CLUSTER_NAME MEMBERSHIP_NAME
   IFS='_' read -r _ PROJECT_ID CLUSTER_LOCATION CLUSTER_NAME < <(echo "$CTX_CLUSTER")
+  local FLEET_ID; FLEET_ID="$(context_get-option "FLEET_ID")"
 
   MEMBERSHIP_NAME="$(generate_membership_name "${PROJECT_ID}" "${CLUSTER_LOCATION}" "${CLUSTER_NAME}")"
 
   info "Registering the cluster ${PROJECT_ID}/${CLUSTER_LOCATION}/${CLUSTER_NAME} as ${MEMBERSHIP_NAME}..."
 
   retry 2 gcloud container hub memberships register "${MEMBERSHIP_NAME}" \
-    --project="${PROJECT_ID}" \
+    --project="${FLEET_ID}" \
     --gke-uri="${GKE_CLUSTER_URI}" \
     --enable-workload-identity
 }


### PR DESCRIPTION
the scripts now successfully registeres the cluster-2 from project `zhengzhe-anthos-test` to `zhengzhe-test-project`
```
2021-09-14T00:36:55.856999 asmcli: Registering the cluster zhengzhe-anthos-test/us-central1-c/cluster-2 as 1631579815789678555...
2021-09-14T00:36:55.999593 asmcli: Running: '/usr/local/google/home/zhengzhey/google-cloud-sdk/bin/gcloud container hub memberships register 1631579815789678555 --project=zhengzhe-test-project --gke-uri=https://container.googleapis.com/v1/projects/zhengzhe-anthos-test/zones/us-central1-c/clusters/cluster-2 --enable-workload-identity'
2021-09-14T00:36:56.066014 asmcli: -------------
kubeconfig entry generated for cluster-2.
Waiting for membership to be created...
...................done.
Created a new membership [projects/zhengzhe-test-project/locations/global/memberships/1631579815789678555] for the cluster [1631579815789678555]
```