### PR TITLE
Add another condition to detect workload identity enablement

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -2034,7 +2034,7 @@ is_workload_identity_enabled() {
     --format=json | \
     jq .workloadIdentityConfig)"
 
-  if [[ "${ENABLED}" = 'null' ]]; then
+  if [[ "${ENABLED}" = 'null' || "${ENABLED}" = '{}' ]]; then
     false;
   else
     WI_ENABLED=1;


### PR DESCRIPTION
This condition could happen when enabling WI, and then disabling it, and re-enabling it.