### PR TITLE
Remove hostNetwork from cni-managed

### DIFF
--- a/asm/istio/options/cni-managed.yaml
+++ b/asm/istio/options/cni-managed.yaml
@@ -325,7 +325,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-      hostNetwork: true
       tolerations:
         # Make sure istio-cni-node gets scheduled on all nodes.
         - effect: NoSchedule


### PR DESCRIPTION
Same change as https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/pull/981