### PR TITLE
Make asmcli resilient to Hub autopush registration

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -2942,7 +2942,7 @@ populate_fleet_info() {
     -n "${HUB_IDP_URL}" ]]; then return; fi
 
   if ! is_membership_crd_installed; then return; fi
-  HUB_MEMBERSHIP_ID="$(kubectl get memberships.hub.gke.io membership -o=json | jq .spec.owner.id | sed 's/^\"\/\/gkehub.googleapis.com\/projects\/\(.*\)\/locations\/global\/memberships\/\(.*\)\"$/\2/g')"
+  HUB_MEMBERSHIP_ID="$(kubectl get memberships.hub.gke.io membership -o=json | jq .spec.owner.id | sed 's/^\"\/\/\(autopush-\)\{0,1\}gkehub\(.sandbox\)\{0,1\}.googleapis.com\/projects\/\(.*\)\/locations\/global\/memberships\/\(.*\)\"$/\4/g')"
   context_set-option "HUB_MEMBERSHIP_ID" "${HUB_MEMBERSHIP_ID}"
   HUB_IDP_URL="$(kubectl get memberships.hub.gke.io membership -o=jsonpath='{.spec.identity_provider}')"
   context_set-option "HUB_IDP_URL" "${HUB_IDP_URL}"


### PR DESCRIPTION
The current sed command doesn't match memberships registered to GKE Hub's autopush instance (example: `//autopush-gkehub.sandbox.googleapis.com/projects/43552690995/locations/global/memberships/ci-tbf1fb9087924ec3`).

Testing:
$ echo $TEST_URI
> "//gkehub.googleapis.com/projects/andash-on-prem/locations/global/memberships/ci-tbf1fb9087924ec3"
$ echo $TEST_URI_AUTOPUSH
> "//autopush-gkehub.sandbox.googleapis.com/projects/43552690995/locations/global/memberships/ci-tbf1fb9087924ec3"
$ echo $TEST_URI | sed 's/^\"\/\/\(autopush-\)\{0,1\}gkehub\(.sandbox\)\{0,1\}.googleapis.com\/projects\/\(.*\)\/locations\/global\/memberships\/\(.*\)\"$/\4/g'
> ci-tbf1fb9087924ec3
$ echo $TEST_URI_AUTOPUSH | sed 's/^\"\/\/\(autopush-\)\{0,1\}gkehub\(.sandbox\)\{0,1\}.googleapis.com\/projects\/\(.*\)\/locations\/global\/memberships\/\(.*\)\"$/\4/g'
> ci-tbf1fb9087924ec3