### PR TITLE
Check return code from runIstiod call

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1917,7 +1917,7 @@ install_managed_control_plane() {
   fi
 
   info "Provisioning control plane..."
-  retry 2 run_command curl --request POST \
+  retry 2 check_curl --request POST \
     "https://meshconfig.googleapis.com/v1alpha1/projects/${PROJECT_ID}/locations/${CLUSTER_LOCATION}/clusters/${CLUSTER_NAME}:runIstiod" \
     --data "${POST_DATA}" \
     --header "X-Server-Timeout: 600" \
@@ -3396,6 +3396,30 @@ run_command() {
   local RETVAL
   { "${@}"; RETVAL="$?"; } || true
   return $RETVAL
+}
+
+######
+# check_curl calls curl and returns non-zero if the http code is not 200 or the
+# curl command fails.
+######
+check_curl() {
+  local TMPFILE; TMPFILE=$(mktemp)
+
+  local HTTPCODE;
+  local RETVAL;
+  HTTPCODE=$(run_command curl --write-out '%{http_code}' --silent --show-error --output "$TMPFILE" "${@}")
+  RETVAL="$?"
+  if [[ "$RETVAL" != "0" ]] ; then
+    return "$RETVAL"
+  fi
+  if [[ "$HTTPCODE" != "200" ]] ; then
+    warn "HTTP response code: ${HTTPCODE}"
+  fi
+  cat "$TMPFILE"
+  if [[ "$HTTPCODE" != "200" ]] ; then
+    false
+    return
+  fi
 }
 
 #######

--- a/asmcli/components/control-plane/managed.sh
+++ b/asmcli/components/control-plane/managed.sh
@@ -26,7 +26,7 @@ install_managed_control_plane() {
   fi
 
   info "Provisioning control plane..."
-  retry 2 run_command curl --request POST \
+  retry 2 check_curl --request POST \
     "https://meshconfig.googleapis.com/v1alpha1/projects/${PROJECT_ID}/locations/${CLUSTER_LOCATION}/clusters/${CLUSTER_NAME}:runIstiod" \
     --data "${POST_DATA}" \
     --header "X-Server-Timeout: 600" \

--- a/asmcli/lib/util.sh
+++ b/asmcli/lib/util.sh
@@ -42,6 +42,30 @@ run_command() {
   return $RETVAL
 }
 
+######
+# check_curl calls curl and returns non-zero if the http code is not 200 or the
+# curl command fails.
+######
+check_curl() {
+  local TMPFILE; TMPFILE=$(mktemp)
+
+  local HTTPCODE;
+  local RETVAL;
+  HTTPCODE=$(run_command curl --write-out '%{http_code}' --silent --show-error --output "$TMPFILE" "${@}")
+  RETVAL="$?"
+  if [[ "$RETVAL" != "0" ]] ; then
+    return "$RETVAL"
+  fi
+  if [[ "$HTTPCODE" != "200" ]] ; then
+    warn "HTTP response code: ${HTTPCODE}"
+  fi
+  cat "$TMPFILE"
+  if [[ "$HTTPCODE" != "200" ]] ; then
+    false
+    return
+  fi
+}
+
 #######
 # retry takes an integer N as the first argument, and a list of arguments
 # representing a command afterwards. It will retry the given command up to N


### PR DESCRIPTION
Check the return code when calling runIstiod, fail if it's not a 200.

When successful, it logs this:
```
2021-09-30T20:36:30.992145 asmcli: Running: 'curl --write-out %{http_code} --silent --show-error --output /tmp/tmp.uMF7JCraIx --request POST https://meshconfig.googleapis.com/v1alpha1/projects/samer-asm-test2/locations/us-central1-b/clusters/somecluster:runIstiod --data {} --header X-Server-Timeout: 600 --header Content-Type: application/json -K /dev/fd/63'
2021-09-30T20:36:31.022427 asmcli: Running: '/usr/bin/gcloud --project=samer-asm-test2 auth print-access-token'
2021-09-30T20:36:31.041526 asmcli: -------------
2021-09-30T20:36:31.073035 asmcli: -------------
{}
```

This is what it looks like when it fails:

```
2021-09-30T20:40:35.943337 asmcli: Provisioning control plane...
2021-09-30T20:40:36.081721 asmcli: Running: 'curl --write-out %{http_code} --silent --show-error --output /tmp/tmp.4CDgHkLmOv --request POST localhost:8000 --data {} --header X-Server-Timeout: 600 --header Content-Type: application/json -K /dev/fd/63'
2021-09-30T20:40:36.111154 asmcli: Running: '/usr/bin/gcloud --project=samer-asm-test2 auth print-access-token'
2021-09-30T20:40:36.141329 asmcli: -------------
2021-09-30T20:40:36.178882 asmcli: -------------
HTTP response code: 500
some important error message
2021-09-30T20:40:37.133772 asmcli: [WARNING]: Failed, retrying...(1 of 2)
2021-09-30T20:40:39.263530 asmcli: Running: 'curl --write-out %{http_code} --silent --show-error --output /tmp/tmp.Sr5aSuZjoX --request POST localhost:8000 --data {} --header X-Server-Timeout: 600 --header Content-Type: application/json -K /dev/fd/63'
2021-09-30T20:40:39.311517 asmcli: -------------
HTTP response code: 500
some important error message
2021-09-30T20:40:39.371207 asmcli: [WARNING]: Failed, retrying...(2 of 2)
2021-09-30T20:40:41.440905 asmcli: [WARNING]: Command 'check_curl --request POST localhost:8000 --data {} --header X-Server-Timeout: 600 --header Content-Type: application/json -K /dev/fd/63' failed.
```