### PR TITLE
Use Cluster Local Project P4SA with Fleet WIP

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -173,7 +173,7 @@ openAPI:
           - marker: PROJECT_ID
             ref: '#/definitions/io.k8s.cli.setters.gcloud.core.project'
           - marker: PROJECT_NUMBER
-            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.environProjectNumber'
+            ref: '#/definitions/io.k8s.cli.setters.gcloud.project.projectNumber'
           - marker: asm-cluster
             ref: '#/definitions/io.k8s.cli.setters.gcloud.container.cluster'
           - marker: us-central1-c

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1879,11 +1879,13 @@ init_meshconfig() {
     info "Cluster has Membership ID ${HUB_MEMBERSHIP_ID} in the Hub of project ${FLEET_ID}"
     # initialize replaces the existing Workload Identity Pools in the IAM binding, so we need to support both Hub and GKE Workload Identity Pools
     local POST_DATA
-    POST_DATA='{"workloadIdentityPools":["'${PROJECT_ID}'.hub.id.goog","'${PROJECT_ID}'.svc.id.goog"]}'
-    init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
+    # Initialize the Hub Hosting project with Hub WIP
+    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
+    init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
     if [[ "${FLEET_ID}" != "${PROJECT_ID}" ]]; then
-      POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
-      init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
+      # Initialize the cluster local project with both Hub WIP and GKE WIP
+      POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog","'${PROJECT_ID}'.svc.id.goog"]}'
+      init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
     fi
   else
     init_meshconfig_curl '' "${PROJECT_ID}"
@@ -1990,11 +1992,13 @@ init_meshconfig_managed() {
 
   info "Initializing meshconfig managed API..."
   local POST_DATA
-  POST_DATA='{"workloadIdentityPools":["'${PROJECT_ID}'.hub.id.goog","'${PROJECT_ID}'.svc.id.goog"], "prepare_istiod": true}'
-  init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
+  # Initialize the Hub Hosting project with Hub WIP
+  POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"], "prepare_istiod": true}'
+  init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
   if [[ "${FLEET_ID}" != "${PROJECT_ID}" ]]; then
-    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
-    init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
+    # Initialize the cluster local project with both Hub WIP and GKE WIP
+    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog","'${PROJECT_ID}'.svc.id.goog"]}'
+    init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
   fi
 }
 has_value() {

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1992,12 +1992,18 @@ init_meshconfig_managed() {
 
   info "Initializing meshconfig managed API..."
   local POST_DATA
+  # When cluster local project is the same as the Hub Hosting Project
+  # Initialize the project with Hub WIP and prepare istiod
+  if [[ "${FLEET_ID}" == "${PROJECT_ID}" ]]; then
+    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"], "prepare_istiod": true}'
+    init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
+  # When cluster local project is different from the Hub Hosting Project
   # Initialize the Hub Hosting project with Hub WIP
-  POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"], "prepare_istiod": true}'
-  init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
-  if [[ "${FLEET_ID}" != "${PROJECT_ID}" ]]; then
-    # Initialize the cluster local project with both Hub WIP and GKE WIP
-    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog","'${PROJECT_ID}'.svc.id.goog"]}'
+  # Initialize the cluster local project with Hub WIP & GKE WIP and prepare istiod
+  else
+    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
+    init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
+    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog","'${PROJECT_ID}'.svc.id.goog"], "prepare_istiod": true}'
     init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
   fi
 }

--- a/asmcli/components/control-plane/in-cluster.sh
+++ b/asmcli/components/control-plane/in-cluster.sh
@@ -37,11 +37,13 @@ init_meshconfig() {
     info "Cluster has Membership ID ${HUB_MEMBERSHIP_ID} in the Hub of project ${FLEET_ID}"
     # initialize replaces the existing Workload Identity Pools in the IAM binding, so we need to support both Hub and GKE Workload Identity Pools
     local POST_DATA
-    POST_DATA='{"workloadIdentityPools":["'${PROJECT_ID}'.hub.id.goog","'${PROJECT_ID}'.svc.id.goog"]}'
-    init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
+    # Initialize the Hub Hosting project with Hub WIP
+    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
+    init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
     if [[ "${FLEET_ID}" != "${PROJECT_ID}" ]]; then
-      POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
-      init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
+      # Initialize the cluster local project with both Hub WIP and GKE WIP
+      POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog","'${PROJECT_ID}'.svc.id.goog"]}'
+      init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
     fi
   else
     init_meshconfig_curl '' "${PROJECT_ID}"

--- a/asmcli/components/control-plane/managed.sh
+++ b/asmcli/components/control-plane/managed.sh
@@ -99,10 +99,12 @@ init_meshconfig_managed() {
 
   info "Initializing meshconfig managed API..."
   local POST_DATA
-  POST_DATA='{"workloadIdentityPools":["'${PROJECT_ID}'.hub.id.goog","'${PROJECT_ID}'.svc.id.goog"], "prepare_istiod": true}'
-  init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
+  # Initialize the Hub Hosting project with Hub WIP
+  POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"], "prepare_istiod": true}'
+  init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
   if [[ "${FLEET_ID}" != "${PROJECT_ID}" ]]; then
-    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
-    init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
+    # Initialize the cluster local project with both Hub WIP and GKE WIP
+    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog","'${PROJECT_ID}'.svc.id.goog"]}'
+    init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
   fi
 }

--- a/asmcli/components/control-plane/managed.sh
+++ b/asmcli/components/control-plane/managed.sh
@@ -99,12 +99,18 @@ init_meshconfig_managed() {
 
   info "Initializing meshconfig managed API..."
   local POST_DATA
+  # When cluster local project is the same as the Hub Hosting Project
+  # Initialize the project with Hub WIP and prepare istiod
+  if [[ "${FLEET_ID}" == "${PROJECT_ID}" ]]; then
+    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"], "prepare_istiod": true}'
+    init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
+  # When cluster local project is different from the Hub Hosting Project
   # Initialize the Hub Hosting project with Hub WIP
-  POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"], "prepare_istiod": true}'
-  init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
-  if [[ "${FLEET_ID}" != "${PROJECT_ID}" ]]; then
-    # Initialize the cluster local project with both Hub WIP and GKE WIP
-    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog","'${PROJECT_ID}'.svc.id.goog"]}'
+  # Initialize the cluster local project with Hub WIP & GKE WIP and prepare istiod
+  else
+    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog"]}'
+    init_meshconfig_curl "${POST_DATA}" "${FLEET_ID}"
+    POST_DATA='{"workloadIdentityPools":["'${FLEET_ID}'.hub.id.goog","'${FLEET_ID}'.svc.id.goog","'${PROJECT_ID}'.svc.id.goog"], "prepare_istiod": true}'
     init_meshconfig_curl "${POST_DATA}" "${PROJECT_ID}"
   fi
 }


### PR DESCRIPTION
This PR implements

- Set PROJECT_NUMBER within GCP_METADATA with cluster local project gcloud.project.projectNumber. This implies the mesh use cluster local project P4SA. 
- Initialize cluster local project with both Fleet WIP and GKE WIP. This will allow Fleet WI impersonate Cluster Local Project P4SA. 