### PR TITLE
Check all possible managed revisions for the validation webhook

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1929,10 +1929,16 @@ install_managed_control_plane() {
     --header "Content-Type: application/json" \
     -K <(auth_header "$(get_auth_token)")
 
-  local VALIDATION_URL; local CLOUDRUN_ADDR;
-  read -r VALIDATION_URL CLOUDRUN_ADDR <<EOF
-$(scrape_managed_urls)
-EOF
+  local MUTATING_WEBHOOK_URL
+  MUTATING_WEBHOOK_URL=$(get_managed_mutating_webhook_url)
+
+  local VALIDATION_URL
+  # shellcheck disable=SC2001
+  VALIDATION_URL="$(echo "${MUTATING_WEBHOOK_URL}" | sed 's/inject.*$/validate/g')"
+
+  local CLOUDRUN_ADDR
+  # shellcheck disable=SC2001
+  CLOUDRUN_ADDR=$(echo "${MUTATING_WEBHOOK_URL}" | cut -d'/' -f3)
 
   kpt cfg set asm anthos.servicemesh.controlplane.validation-url "${VALIDATION_URL}"
   kpt cfg set asm anthos.servicemesh.managed-controlplane.cloudrun-addr "${CLOUDRUN_ADDR}"
@@ -1978,19 +1984,20 @@ configure_managed_control_plane() {
   :
 }
 
-scrape_managed_urls() {
-  local URL
-  URL="$(kubectl get mutatingwebhookconfiguration istiod-asm-managed -ojson | jq .webhooks[0].clientConfig.url -r)"
+get_managed_mutating_webhook_url() {
+  # Get the url for the most up to date channel that the cluster is using.
+  local WEBHOOKS; WEBHOOKS="istiod-asm-managed-rapid istiod-asm-managed istiod-asm-managed-stable"
+  local WEBHOOK_JSON
 
-  local VALIDATION_URL
-  # shellcheck disable=SC2001
-  VALIDATION_URL="$(echo "${URL}" | sed 's/inject.*$/validate/g')"
+  for WEBHOOK in $WEBHOOKS; do
+    if WEBHOOK_JSON="$(kubectl get mutatingwebhookconfiguration "${WEBHOOK}" -ojson)" ; then
+      info "Using the following managed revision for validating webhook: ${WEBHOOK#'istiod-'}"
+      echo "$WEBHOOK_JSON" | jq .webhooks[0].clientConfig.url -r
+      return
+    fi
+  done
 
-  local CLOUDRUN_ADDR
-  # shellcheck disable=SC2001
-  CLOUDRUN_ADDR=$(echo "${URL}" | cut -d'/' -f3)
-
-  echo "${VALIDATION_URL} ${CLOUDRUN_ADDR}"
+  fatal "Could not find managed config map."
 }
 
 

--- a/asmcli/components/control-plane/managed.sh
+++ b/asmcli/components/control-plane/managed.sh
@@ -33,10 +33,16 @@ install_managed_control_plane() {
     --header "Content-Type: application/json" \
     -K <(auth_header "$(get_auth_token)")
 
-  local VALIDATION_URL; local CLOUDRUN_ADDR;
-  read -r VALIDATION_URL CLOUDRUN_ADDR <<EOF
-$(scrape_managed_urls)
-EOF
+  local MUTATING_WEBHOOK_URL
+  MUTATING_WEBHOOK_URL=$(get_managed_mutating_webhook_url)
+
+  local VALIDATION_URL
+  # shellcheck disable=SC2001
+  VALIDATION_URL="$(echo "${MUTATING_WEBHOOK_URL}" | sed 's/inject.*$/validate/g')"
+
+  local CLOUDRUN_ADDR
+  # shellcheck disable=SC2001
+  CLOUDRUN_ADDR=$(echo "${MUTATING_WEBHOOK_URL}" | cut -d'/' -f3)
 
   kpt cfg set asm anthos.servicemesh.controlplane.validation-url "${VALIDATION_URL}"
   kpt cfg set asm anthos.servicemesh.managed-controlplane.cloudrun-addr "${CLOUDRUN_ADDR}"
@@ -82,19 +88,20 @@ configure_managed_control_plane() {
   :
 }
 
-scrape_managed_urls() {
-  local URL
-  URL="$(kubectl get mutatingwebhookconfiguration istiod-asm-managed -ojson | jq .webhooks[0].clientConfig.url -r)"
+get_managed_mutating_webhook_url() {
+  # Get the url for the most up to date channel that the cluster is using.
+  local WEBHOOKS; WEBHOOKS="istiod-asm-managed-rapid istiod-asm-managed istiod-asm-managed-stable"
+  local WEBHOOK_JSON
 
-  local VALIDATION_URL
-  # shellcheck disable=SC2001
-  VALIDATION_URL="$(echo "${URL}" | sed 's/inject.*$/validate/g')"
+  for WEBHOOK in $WEBHOOKS; do
+    if WEBHOOK_JSON="$(kubectl get mutatingwebhookconfiguration "${WEBHOOK}" -ojson)" ; then
+      info "Using the following managed revision for validating webhook: ${WEBHOOK#'istiod-'}"
+      echo "$WEBHOOK_JSON" | jq .webhooks[0].clientConfig.url -r
+      return
+    fi
+  done
 
-  local CLOUDRUN_ADDR
-  # shellcheck disable=SC2001
-  CLOUDRUN_ADDR=$(echo "${URL}" | cut -d'/' -f3)
-
-  echo "${VALIDATION_URL} ${CLOUDRUN_ADDR}"
+  fatal "Could not find managed config map."
 }
 
 


### PR DESCRIPTION
Instead of just checking for asm-managed, check for asm-managed-rapid,
asm-managed, and asm-managed-stable in that order, and use the first
webhook that exists as the validating webhook.

This will allow the managed control plane to return a subset of
revisions (for code that uses new features, e.g. fleet memberships),
instead of always needing to create the asm-managed revision.

Output:
```
2021-10-04T21:39:05.260052 asmcli: Running: '/usr/bin/kubectl --kubeconfig asm_kubeconfig --context gke_samer-asm-test2_us-central1-b_somecluster get mutatingwebhookconfiguration istiod-asm-managed-rapid -ojson'
2021-10-04T21:39:05.335782 asmcli: -------------
2021-10-04T21:39:05.593078 asmcli: Using the following managed revision for validating webhook: asm-managed-rapid
2021-10-04T21:39:05.792370 asmcli: Running: '/tmp/tmp.FeP3PlRI8j/kpt cfg set asm anthos.servicemesh.controlplane.validation-url https://asm-somecluster-asm-managed-rapid-b-2jmenkxu2q-uc.a.run.app:443/validate'
2021-10-04T21:39:05.868586 asmcli: -------------
asm/
set 1 field(s) of setter "anthos.servicemesh.controlplane.validation-url" to value "https://asm-somecluster-asm-managed-rapid-b-2jmenkxu2q-uc.a.run.app:443/validate"
2021-10-04T21:39:06.876788 asmcli: Running: '/tmp/tmp.FeP3PlRI8j/kpt cfg set asm anthos.servicemesh.managed-controlplane.cloudrun-addr asm-somecluster-asm-managed-rapid-b-2jmenkxu2q-uc.a.run.app:443'
2021-10-04T21:39:06.916475 asmcli: -------------
asm/
set 1 field(s) of setter "anthos.servicemesh.managed-controlplane.cloudrun-addr" to value "asm-somecluster-asm-managed-rapid-b-2jmenkxu2q-uc.a.run.app:443"
```