### PR TITLE
Respect --network_id for non-GCP platforms

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -4099,8 +4099,6 @@ EOF
     if [[ -n "${NEW_NETWORK_ID}" ]]; then
       context_set-option "NETWORK_ID" "${PROJECT_ID}-${NEW_NETWORK_ID}"
     fi
-  else
-    context_set-option "NETWORK_ID" "default"
   fi
 }
 

--- a/asmcli/lib/util.sh
+++ b/asmcli/lib/util.sh
@@ -625,8 +625,6 @@ EOF
     if [[ -n "${NEW_NETWORK_ID}" ]]; then
       context_set-option "NETWORK_ID" "${PROJECT_ID}-${NEW_NETWORK_ID}"
     fi
-  else
-    context_set-option "NETWORK_ID" "default"
   fi
 }
 


### PR DESCRIPTION
Before, when not using a non-GCP platform, we'd ignore what's passed in for --network_id and use "default". After this we'll use what's set in the flag and leave unset otherwise.