### PR TITLE
Fix null gcloud.compute.network for multicloud installations

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -4100,6 +4100,7 @@ populate_cluster_values() {
   local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
   local CLUSTER_NAME; CLUSTER_NAME="$(context_get-option "CLUSTER_NAME")"
   local CLUSTER_LOCATION; CLUSTER_LOCATION="$(context_get-option "CLUSTER_LOCATION")"
+  local NETWORK_ID; NETWORK_ID="$(context_get-option "NETWORK_ID")"
   local CLUSTER_DATA
 
   if is_gcp; then
@@ -4116,6 +4117,10 @@ EOF
     fi
     if [[ -n "${NEW_NETWORK_ID}" ]]; then
       context_set-option "NETWORK_ID" "${PROJECT_ID}-${NEW_NETWORK_ID}"
+    fi
+  else
+    if [[ -z "${NETWORK_ID}" ]]; then
+      context_set-option "NETWORK_ID" "default"
     fi
   fi
 }

--- a/asmcli/lib/util.sh
+++ b/asmcli/lib/util.sh
@@ -611,6 +611,7 @@ populate_cluster_values() {
   local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
   local CLUSTER_NAME; CLUSTER_NAME="$(context_get-option "CLUSTER_NAME")"
   local CLUSTER_LOCATION; CLUSTER_LOCATION="$(context_get-option "CLUSTER_LOCATION")"
+  local NETWORK_ID; NETWORK_ID="$(context_get-option "NETWORK_ID")"
   local CLUSTER_DATA
 
   if is_gcp; then
@@ -627,6 +628,10 @@ EOF
     fi
     if [[ -n "${NEW_NETWORK_ID}" ]]; then
       context_set-option "NETWORK_ID" "${PROJECT_ID}-${NEW_NETWORK_ID}"
+    fi
+  else
+    if [[ -z "${NETWORK_ID}" ]]; then
+      context_set-option "NETWORK_ID" "default"
     fi
   fi
 }


### PR DESCRIPTION
Fixes a bug in https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/pull/1018. Assumed that leaving NETWORK_ID as empty string would be fine, but caused 

```
error: The input value doesn't validate against provided OpenAPI schema: validation failure list:
gcloud.compute.network in body must be of type string: "null"
```