### PR TITLE
fix a bug when mech_ca api is not enabled for x install

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -5029,6 +5029,7 @@ x_validate_install_args() {
   local CLUSTER_LOCATION; CLUSTER_LOCATION="$(context_get-option "CLUSTER_LOCATION")"
   local MANAGED; MANAGED="$(context_get-option "MANAGED")"
   local FLEET_ID; FLEET_ID="$(context_get-option "FLEET_ID")"
+  local CA; CA="$(context_get-option "CA")"
   local ENABLE_ALL; ENABLE_ALL="$(context_get-option "ENABLE_ALL")"
   local ENABLE_CLUSTER_ROLES; ENABLE_CLUSTER_ROLES="$(context_get-option "ENABLE_CLUSTER_ROLES")"
   local ENABLE_CLUSTER_LABELS; ENABLE_CLUSTER_LABELS="$(context_get-option "ENABLE_CLUSTER_LABELS")"
@@ -5052,6 +5053,11 @@ x_validate_install_args() {
   local CONTEXT; CONTEXT="$(context_get-option "CONTEXT")"
   local KUBECONFIG_SUPPLIED; KUBECONFIG_SUPPLIED="$(context_get-option "KUBECONFIG_SUPPLIED")"
   local CHANNEL; CHANNEL="$(context_get-option "CHANNEL")"
+
+  if [[ -z "${CA}" ]]; then
+    CA="mesh_ca"
+    context_set-option "CA" "${CA}"
+  fi
 
   local MISSING_ARGS=0
 

--- a/asmcli/lib/validate.sh
+++ b/asmcli/lib/validate.sh
@@ -744,6 +744,7 @@ x_validate_install_args() {
   local CLUSTER_LOCATION; CLUSTER_LOCATION="$(context_get-option "CLUSTER_LOCATION")"
   local MANAGED; MANAGED="$(context_get-option "MANAGED")"
   local FLEET_ID; FLEET_ID="$(context_get-option "FLEET_ID")"
+  local CA; CA="$(context_get-option "CA")"
   local ENABLE_ALL; ENABLE_ALL="$(context_get-option "ENABLE_ALL")"
   local ENABLE_CLUSTER_ROLES; ENABLE_CLUSTER_ROLES="$(context_get-option "ENABLE_CLUSTER_ROLES")"
   local ENABLE_CLUSTER_LABELS; ENABLE_CLUSTER_LABELS="$(context_get-option "ENABLE_CLUSTER_LABELS")"
@@ -767,6 +768,11 @@ x_validate_install_args() {
   local CONTEXT; CONTEXT="$(context_get-option "CONTEXT")"
   local KUBECONFIG_SUPPLIED; KUBECONFIG_SUPPLIED="$(context_get-option "KUBECONFIG_SUPPLIED")"
   local CHANNEL; CHANNEL="$(context_get-option "CHANNEL")"
+
+  if [[ -z "${CA}" ]]; then
+    CA="mesh_ca"
+    context_set-option "CA" "${CA}"
+  fi
 
   local MISSING_ARGS=0
 


### PR DESCRIPTION
```
2021-10-27T02:45:22.123891 asmcli: Enabling required APIs...
2021-10-27T02:45:22.312602 asmcli: Running: '/usr/local/google/home/zhengzhey/google-cloud-sdk/bin/gcloud services enable --project=asm-bugbash-20210910-02 container.googleapis.com monitoring.googleapis.com logging.googleapis.com cloudtrace.googleapis.com meshconfig.googleapis.com iamcredentials.googleapis.com gkeconnect.googleapis.com gkehub.googleapis.com cloudresourcemanager.googleapis.com stackdriver.googleapis.com meshca.googleapis.com'
```