### PR TITLE
fix create-mesh cluster names

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -299,14 +299,14 @@ install_one_remote_secret() {
 
   context_set-option "KUBECONFIG" "${KCF1}"
   CTX1="$(kubectl config current-context)"
+
+  SECRET_NAME="${CTX1//_/-}"
+  SECRET_NAME="${SECRET_NAME//\./-}"
+  SECRET_NAME="${SECRET_NAME//@/-}"
   if [[ "${SECRET_NAME}" =~ ^gke_[^_]+_[^_]+_.+ ]]; then
     local CTX_PROJECT CTX_LOCATION CTX_CLUSTER
     IFS="_" read -r _ CTX_PROJECT CTX_LOCATION CTX_CLUSTER <<<"$(context_get-option "CONTEXT")"
     SECRET_NAME="cn-${CTX_PROJECT}-${CTX_LOCATION}-${CTX_CLUSTER}"
-  else
-    SECRET_NAME="${CTX1//_/-}"
-    SECRET_NAME="${SECRET_NAME//\./-}"
-    SECRET_NAME="${SECRET_NAME//@/-}"
   fi
   SECRET_NAME="$(generate_secret_name "${SECRET_NAME}")"
 

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -299,10 +299,17 @@ install_one_remote_secret() {
 
   context_set-option "KUBECONFIG" "${KCF1}"
   CTX1="$(kubectl config current-context)"
-  SECRET_NAME="${CTX1//_/-}"
-  SECRET_NAME="${SECRET_NAME//\./-}"
-  SECRET_NAME="${SECRET_NAME//@/-}"
+  if [[ "${SECRET_NAME}" =~ ^gke_[^_]+_[^_]+_.+ ]]; then
+    local CTX_PROJECT CTX_LOCATION CTX_CLUSTER
+    IFS="_" read -r _ CTX_PROJECT CTX_LOCATION CTX_CLUSTER <<<"$(context_get-option "CONTEXT")"
+    SECRET_NAME="cn-${CTX_PROJECT}-${CTX_LOCATION}-${CTX_CLUSTER}"
+  else
+    SECRET_NAME="${CTX1//_/-}"
+    SECRET_NAME="${SECRET_NAME//\./-}"
+    SECRET_NAME="${SECRET_NAME//@/-}"
+  fi
   SECRET_NAME="$(generate_secret_name "${SECRET_NAME}")"
+
   context_set-option "KUBECONFIG" "${KCF2}"
   local CTX2; CTX2="$(kubectl config current-context)"
 

--- a/asmcli/commands/create-mesh.sh
+++ b/asmcli/commands/create-mesh.sh
@@ -164,10 +164,17 @@ install_one_remote_secret() {
 
   context_set-option "KUBECONFIG" "${KCF1}"
   CTX1="$(kubectl config current-context)"
-  SECRET_NAME="${CTX1//_/-}"
-  SECRET_NAME="${SECRET_NAME//\./-}"
-  SECRET_NAME="${SECRET_NAME//@/-}"
+  if [[ "${SECRET_NAME}" =~ ^gke_[^_]+_[^_]+_.+ ]]; then
+    local CTX_PROJECT CTX_LOCATION CTX_CLUSTER
+    IFS="_" read -r _ CTX_PROJECT CTX_LOCATION CTX_CLUSTER <<<"$(context_get-option "CONTEXT")"
+    SECRET_NAME="cn-${CTX_PROJECT}-${CTX_LOCATION}-${CTX_CLUSTER}"
+  else
+    SECRET_NAME="${CTX1//_/-}"
+    SECRET_NAME="${SECRET_NAME//\./-}"
+    SECRET_NAME="${SECRET_NAME//@/-}"
+  fi
   SECRET_NAME="$(generate_secret_name "${SECRET_NAME}")"
+
   context_set-option "KUBECONFIG" "${KCF2}"
   local CTX2; CTX2="$(kubectl config current-context)"
 

--- a/asmcli/commands/create-mesh.sh
+++ b/asmcli/commands/create-mesh.sh
@@ -164,14 +164,14 @@ install_one_remote_secret() {
 
   context_set-option "KUBECONFIG" "${KCF1}"
   CTX1="$(kubectl config current-context)"
+
+  SECRET_NAME="${CTX1//_/-}"
+  SECRET_NAME="${SECRET_NAME//\./-}"
+  SECRET_NAME="${SECRET_NAME//@/-}"
   if [[ "${SECRET_NAME}" =~ ^gke_[^_]+_[^_]+_.+ ]]; then
     local CTX_PROJECT CTX_LOCATION CTX_CLUSTER
     IFS="_" read -r _ CTX_PROJECT CTX_LOCATION CTX_CLUSTER <<<"$(context_get-option "CONTEXT")"
     SECRET_NAME="cn-${CTX_PROJECT}-${CTX_LOCATION}-${CTX_CLUSTER}"
-  else
-    SECRET_NAME="${CTX1//_/-}"
-    SECRET_NAME="${SECRET_NAME//\./-}"
-    SECRET_NAME="${SECRET_NAME//@/-}"
   fi
   SECRET_NAME="$(generate_secret_name "${SECRET_NAME}")"
 


### PR DESCRIPTION
The `--name` flag should match the cluster name used for install. 