### PR TITLE
Add use_vpcsc flag to the main asmcli managed command

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1185,6 +1185,9 @@ FLAGS:
                                       instead of installing one in-cluster.
      --legacy                         Provision a remote, managed control plane with
                                       the legacy asmcli installer that runs client-side.
+     --use_vpcsc                      Provision a remote, managed control plane in
+                                      VPCSC environment. Not supported for --legacy
+                                      installation method.
 
      --print_config                   Instead of installing ASM, print all of
                                       the compiled YAML to stdout. All other
@@ -1276,6 +1279,7 @@ FLAGS:
 
      --managed
      --legacy
+     --use_vpcsc
 
      --print_config
      --disable_canonical_service
@@ -3360,6 +3364,10 @@ parse_args() {
         ;;
       --legacy)
         context_set-option "LEGACY" 1
+        shift 1
+        ;;
+      --use_vpcsc | --use-vpcsc)
+        context_set-option "USE_VPCSC" 1
         shift 1
         ;;
       --disable_canonical_service | --disable-canonical-service)

--- a/asmcli/commands/help.sh
+++ b/asmcli/commands/help.sh
@@ -180,6 +180,9 @@ FLAGS:
                                       instead of installing one in-cluster.
      --legacy                         Provision a remote, managed control plane with
                                       the legacy asmcli installer that runs client-side.
+     --use_vpcsc                      Provision a remote, managed control plane in
+                                      VPCSC environment. Not supported for --legacy
+                                      installation method.
 
      --print_config                   Instead of installing ASM, print all of
                                       the compiled YAML to stdout. All other
@@ -271,6 +274,7 @@ FLAGS:
 
      --managed
      --legacy
+     --use_vpcsc
 
      --print_config
      --disable_canonical_service

--- a/asmcli/lib/parse.sh
+++ b/asmcli/lib/parse.sh
@@ -131,6 +131,10 @@ parse_args() {
         context_set-option "LEGACY" 1
         shift 1
         ;;
+      --use_vpcsc | --use-vpcsc)
+        context_set-option "USE_VPCSC" 1
+        shift 1
+        ;;
       --disable_canonical_service | --disable-canonical-service)
         context_set-option "DISABLE_CANONICAL_SERVICE" 1
         shift 1


### PR DESCRIPTION
This is for fixing the vpcsc test failure on GoB when getting the most recent asmcli.