### PR TITLE
Adding missing CA specification for asmcli x

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -5142,6 +5142,7 @@ x_validate_install_args() {
   local CLUSTER_LOCATION; CLUSTER_LOCATION="$(context_get-option "CLUSTER_LOCATION")"
   local MANAGED; MANAGED="$(context_get-option "MANAGED")"
   local FLEET_ID; FLEET_ID="$(context_get-option "FLEET_ID")"
+  local CA; CA="$(context_get-option "CA")"
   local ENABLE_ALL; ENABLE_ALL="$(context_get-option "ENABLE_ALL")"
   local ENABLE_CLUSTER_ROLES; ENABLE_CLUSTER_ROLES="$(context_get-option "ENABLE_CLUSTER_ROLES")"
   local ENABLE_CLUSTER_LABELS; ENABLE_CLUSTER_LABELS="$(context_get-option "ENABLE_CLUSTER_LABELS")"
@@ -5165,6 +5166,11 @@ x_validate_install_args() {
   local CONTEXT; CONTEXT="$(context_get-option "CONTEXT")"
   local KUBECONFIG_SUPPLIED; KUBECONFIG_SUPPLIED="$(context_get-option "KUBECONFIG_SUPPLIED")"
   local CHANNEL; CHANNEL="$(context_get-option "CHANNEL")"
+
+  if [[ -z "${CA}" ]]; then
+    CA="mesh_ca"
+    context_set-option "CA" "${CA}"
+  fi
 
   local MISSING_ARGS=0
 

--- a/asmcli/lib/validate.sh
+++ b/asmcli/lib/validate.sh
@@ -756,6 +756,7 @@ x_validate_install_args() {
   local CLUSTER_LOCATION; CLUSTER_LOCATION="$(context_get-option "CLUSTER_LOCATION")"
   local MANAGED; MANAGED="$(context_get-option "MANAGED")"
   local FLEET_ID; FLEET_ID="$(context_get-option "FLEET_ID")"
+  local CA; CA="$(context_get-option "CA")"
   local ENABLE_ALL; ENABLE_ALL="$(context_get-option "ENABLE_ALL")"
   local ENABLE_CLUSTER_ROLES; ENABLE_CLUSTER_ROLES="$(context_get-option "ENABLE_CLUSTER_ROLES")"
   local ENABLE_CLUSTER_LABELS; ENABLE_CLUSTER_LABELS="$(context_get-option "ENABLE_CLUSTER_LABELS")"
@@ -779,6 +780,11 @@ x_validate_install_args() {
   local CONTEXT; CONTEXT="$(context_get-option "CONTEXT")"
   local KUBECONFIG_SUPPLIED; KUBECONFIG_SUPPLIED="$(context_get-option "KUBECONFIG_SUPPLIED")"
   local CHANNEL; CHANNEL="$(context_get-option "CHANNEL")"
+
+  if [[ -z "${CA}" ]]; then
+    CA="mesh_ca"
+    context_set-option "CA" "${CA}"
+  fi
 
   local MISSING_ARGS=0
 


### PR DESCRIPTION
For 1.11, only mesh_ca is supported for asmcli x.
Without specifying the CA variable, asmcli will not enable the
meshca API given a new project.
Assign default value to CA variable in validate function. This
aligns with the behaviour of asmcli (non x).