### PR TITLE
Create `distroless-proxy` option

### DIFF
--- a/asm/istio/options/distroless-proxy
+++ b/asm/istio/options/distroless-proxy
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START docs]
+---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  meshConfig:
+    defaultConfig:
+      image:
+        imageType: distroless
+# [END docs]


### PR DESCRIPTION
With the [recent announcement](https://cloud.google.com/service-mesh/docs/release-notes#December_09_2021) about the option to leverage a distroless image for the proxy, I'm wondering if we could add this file which will allow to use the `--option distroless-proxy` parameter when using `asmcli` instead of having to create that file like explained here https://cloud.google.com/service-mesh/docs/unified-install/options/enable-optional-features#distroless_proxy_image.