### PR TITLE
security: update `onlineboutique` to latest v0.3.3

### DIFF
--- a/samples/online-boutique/kubernetes-manifests/deployments/adservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/adservice.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/adservice:v0.2.2
+          image: gcr.io/google-samples/microservices-demo/adservice:v0.3.3
           ports:
             - containerPort: 9555
           env:

--- a/samples/online-boutique/kubernetes-manifests/deployments/cartservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/cartservice.yaml
@@ -36,7 +36,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.2.2
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.3
         ports:
         - containerPort: 7070
         env:

--- a/samples/online-boutique/kubernetes-manifests/deployments/checkoutservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/checkoutservice.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: checkout
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.2.2
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.3
           ports:
           - containerPort: 5050
           readinessProbe:

--- a/samples/online-boutique/kubernetes-manifests/deployments/currencyservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/currencyservice.yaml
@@ -36,7 +36,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.2.2
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.3
         ports:
         - name: grpc
           containerPort: 7000

--- a/samples/online-boutique/kubernetes-manifests/deployments/emailservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/emailservice.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: email
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.2.2
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.3
         ports:
         - containerPort: 8080
         env:

--- a/samples/online-boutique/kubernetes-manifests/deployments/frontend.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/frontend.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: frontend
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.2.2
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.3.3
           ports:
           - containerPort: 8080
           readinessProbe:

--- a/samples/online-boutique/kubernetes-manifests/deployments/loadgenerator.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/loadgenerator.yaml
@@ -39,7 +39,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: main
-        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.2.2
+        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.3.3
         env:
         - name: FRONTEND_ADDR
           value: "frontend.frontend.svc.cluster.local:80"

--- a/samples/online-boutique/kubernetes-manifests/deployments/paymentservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/paymentservice.yaml
@@ -36,7 +36,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.2.2
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.3
         ports:
         - containerPort: 50051
         env:

--- a/samples/online-boutique/kubernetes-manifests/deployments/productcatalogservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/productcatalogservice.yaml
@@ -36,7 +36,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.2.2
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.3
         ports:
         - containerPort: 3550
         env:

--- a/samples/online-boutique/kubernetes-manifests/deployments/recommendationservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/recommendationservice.yaml
@@ -36,7 +36,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.2.2
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.3
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/samples/online-boutique/kubernetes-manifests/deployments/shippingservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/shippingservice.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: shipping
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.2.2
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.3
         ports:
         - containerPort: 50051
         env:


### PR DESCRIPTION
Use the latest version of `onlineboutique` with the fix for CVE in log4j

https://github.com/GoogleCloudPlatform/microservices-demo/releases/tag/v0.3.3

This is leveraged for example here: https://cloud.google.com/service-mesh/docs/onlineboutique-install-kpt