### PR TITLE
validate node pool workload identity

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1740,11 +1740,15 @@ validate_dependencies() {
 }
 
 validate_control_plane() {
-  if is_managed && is_legacy; then
-    # Managed legacy must be able to set IAM permissions on a generated user, so the flow
-    # is a bit different
-    validate_managed_control_plane_legacy
-  elif ! is_managed; then
+  if is_managed; then
+    if is_legacy; then
+      # Managed legacy must be able to set IAM permissions on a generated user, so the flow
+      # is a bit different
+      validate_managed_control_plane_legacy
+    fi
+    # Node-level Workload Identity is required for managed CNI
+    validate_node_pool_workload_identity
+  else
     validate_in_cluster_control_plane
   fi
 }
@@ -2428,7 +2432,7 @@ is_service_mesh_feature_enabled() {
   local RESPONSE
   RESPONSE="$(run_command gcloud beta container hub mesh describe --project="${FLEET_ID}")"
 
-  if [[ "$(echo "${RESPONSE}" | jq -r '.featureState.lifecycleState')" != "ENABLED" ]]; then
+  if [[ "$(echo "${RESPONSE}" | jq -r '.featureState.lifecycleState' 2>/dev/null)" != "ENABLED" ]]; then
     false
   fi
 }
@@ -4673,6 +4677,25 @@ machine type is at least ${MACHINE_CPU_REQ} vCPUs.
 ${CLUSTER_LOCATION}/${CLUSTER_NAME} does not meet this requirement. ASM
 may not function as expected.
 
+EOF
+  fi
+}
+
+validate_node_pool_workload_identity(){
+  local METADATA_CONFIG_MODE MACHINE_CPU_REQ
+  # No CPU requirement for Managed ASM
+  MACHINE_CPU_REQ=0
+  METADATA_CONFIG_MODE="$(list_valid_pools "${MACHINE_CPU_REQ}" | \
+      jq -r '.[] |
+        .config.workloadMetadataConfig.mode
+      ' 2>/dev/null)" || true
+  if [[ "${METADATA_CONFIG_MODE}" != "GKE_METADATA" ]]; then
+    { read -r -d '' MSG; validation_error "${MSG}"; } <<EOF || true
+Node pool Workload Identity is not enabled which is a pre-requisite for Managed ASM.
+Please follow:
+  https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#migrate_applications_to 
+to migrate or update to a Workload Identity Enabled Node pool. 
+If installation continues, Managed ASM components such as CNI will not work properly.
 EOF
   fi
 }

--- a/asmcli/commands/validate.sh
+++ b/asmcli/commands/validate.sh
@@ -91,11 +91,15 @@ validate_dependencies() {
 }
 
 validate_control_plane() {
-  if is_managed && is_legacy; then
-    # Managed legacy must be able to set IAM permissions on a generated user, so the flow
-    # is a bit different
-    validate_managed_control_plane_legacy
-  elif ! is_managed; then
+  if is_managed; then
+    if is_legacy; then
+      # Managed legacy must be able to set IAM permissions on a generated user, so the flow
+      # is a bit different
+      validate_managed_control_plane_legacy
+    fi
+    # Node-level Workload Identity is required for managed CNI
+    validate_node_pool_workload_identity
+  else
     validate_in_cluster_control_plane
   fi
 }

--- a/asmcli/lib/checks.sh
+++ b/asmcli/lib/checks.sh
@@ -242,7 +242,7 @@ is_service_mesh_feature_enabled() {
   local RESPONSE
   RESPONSE="$(run_command gcloud beta container hub mesh describe --project="${FLEET_ID}")"
 
-  if [[ "$(echo "${RESPONSE}" | jq -r '.featureState.lifecycleState')" != "ENABLED" ]]; then
+  if [[ "$(echo "${RESPONSE}" | jq -r '.featureState.lifecycleState' 2>/dev/null)" != "ENABLED" ]]; then
     false
   fi
 }


### PR DESCRIPTION
Workload identity should be enabled on Node pools. This PR adds a check to make sure the WI is enabled at node-level which is a requirement for Managed ASM (the cluster-level WI will continued to be updated in the script if it's not enabled). If the user create the cluster without `--workload-pool` option but later update the cluster, the existing node pool will not be touched. (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#enable_on_cluster) 
> To enable Workload Identity on an existing cluster, modify the cluster with the following command:
gcloud container clusters update CLUSTER_NAME \
    --workload-pool=PROJECT_ID.svc.id.goog
Existing node pools are unaffected; new node pools default to --workload-metadata=GKE_METADATA.

Test result: 
Updated cluster with node pool that does not have WI enabled:
```
2021-12-23T19:53:54.515581 asmcli: [ERROR]: Node pool Workload Identity is not enabled which is a pre-requisite for Managed ASM.
2021-12-23T19:53:54.515665 Please follow:
2021-12-23T19:53:54.515677   https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#migrate_applications_to 
2021-12-23T19:53:54.515694 to migrate or update to a Workload Identity Enabled Node pool. 
2021-12-23T19:53:54.515754 If installation continues, Managed ASM features such as CNI might not work properly.
2021-12-23T19:53:54.741035 asmcli: [WARNING]: Please see the errors above.
```