### PR TITLE
managed cni enablement default to empty string

### DIFF
--- a/asm/control-plane-revision/cr_rapid.yaml
+++ b/asm/control-plane-revision/cr_rapid.yaml
@@ -5,7 +5,7 @@ metadata:
   name: asm-managed-rapid
   namespace: istio-system
   labels:
-    mesh.cloud.google.com/managed-cni-enabled: "false" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.use-managed-cni"}
+    mesh.cloud.google.com/managed-cni-enabled: "" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.use-managed-cni"}
     app.kubernetes.io/created-by: "" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.created-by"}
   annotations:
     mesh.cloud.google.com/image: "" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-mcp-image"}

--- a/asm/control-plane-revision/cr_regular.yaml
+++ b/asm/control-plane-revision/cr_regular.yaml
@@ -5,7 +5,7 @@ metadata:
   name: asm-managed
   namespace: istio-system
   labels:
-    mesh.cloud.google.com/managed-cni-enabled: "false" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.use-managed-cni"}
+    mesh.cloud.google.com/managed-cni-enabled: "" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.use-managed-cni"}
     app.kubernetes.io/created-by: "" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.created-by"}
   annotations:
     mesh.cloud.google.com/image: "" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-mcp-image"}

--- a/asm/control-plane-revision/cr_stable.yaml
+++ b/asm/control-plane-revision/cr_stable.yaml
@@ -5,7 +5,7 @@ metadata:
   name: asm-managed-stable
   namespace: istio-system
   labels:
-    mesh.cloud.google.com/managed-cni-enabled: "false" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.use-managed-cni"}
+    mesh.cloud.google.com/managed-cni-enabled: "" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.use-managed-cni"}
     app.kubernetes.io/created-by: "" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.created-by"}
   annotations:
     mesh.cloud.google.com/image: "" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-mcp-image"}


### PR DESCRIPTION
The default "false" will lead the user to think that the CNI is disabled, which is almost always not true since CNI should now be enabled for any installation path. Therefore, defaulting to an empty string could reduce confusion. 