### PR TITLE
skip autopilot clusters when validating node pool worklaod identity

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -89,6 +89,7 @@ KPT_BRANCH=""
 RAW_YAML=""
 EXPANDED_YAML=""
 NAMESPACE_EXISTS=0
+IS_AUTOPILOT=0
 
 main() {
   if [[ "${*}" = '' ]]; then
@@ -2645,6 +2646,19 @@ istio_namespace_exists() {
     NAMESPACE_EXISTS=1; readonly NAMESPACE_EXISTS
   fi
 }
+
+is_autopilot() {
+  # TODO: wait till https://pkg.go.dev/google.golang.org/genproto/googleapis/container/v1#Cluster  
+  # publish the `Autopilot` field
+  # This is a temporary workaround to check if a cluster is Autopilot or GKE
+  # This CRD will be installed only if the cluster is Autopilot
+  if [[ "${IS_AUTOPILOT}" -eq 1 ]]; then return; fi
+  if ! retry 2 kubectl get crd allowlistedworkloads.auto.gke.io 1>/dev/null 2>/dev/null; then
+    false
+  else
+    IS_AUTOPILOT=1; readonly IS_AUTOPILOT
+  fi
+}
 configure_package() {
   local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
   local CLUSTER_NAME; CLUSTER_NAME="$(context_get-option "CLUSTER_NAME")"
@@ -4683,6 +4697,11 @@ EOF
 }
 
 validate_node_pool_workload_identity(){
+  # Autopilot clusters do not allow accessing/mutating the node pools
+  # so we skip in such cases.
+  if is_autopilot; then
+    return
+  fi
   local METADATA_CONFIG_MODE MACHINE_CPU_REQ
   # No CPU requirement for Managed ASM
   MACHINE_CPU_REQ=0

--- a/asmcli/asmcli.sh
+++ b/asmcli/asmcli.sh
@@ -85,6 +85,7 @@ KPT_BRANCH=""
 RAW_YAML=""
 EXPANDED_YAML=""
 NAMESPACE_EXISTS=0
+IS_AUTOPILOT=0
 
 main() {
   if [[ "${*}" = '' ]]; then

--- a/asmcli/lib/checks.sh
+++ b/asmcli/lib/checks.sh
@@ -455,3 +455,16 @@ istio_namespace_exists() {
     NAMESPACE_EXISTS=1; readonly NAMESPACE_EXISTS
   fi
 }
+
+is_autopilot() {
+  # TODO: wait till https://pkg.go.dev/google.golang.org/genproto/googleapis/container/v1#Cluster  
+  # publish the `Autopilot` field
+  # This is a temporary workaround to check if a cluster is Autopilot or GKE
+  # This CRD will be installed only if the cluster is Autopilot
+  if [[ "${IS_AUTOPILOT}" -eq 1 ]]; then return; fi
+  if ! retry 2 kubectl get crd allowlistedworkloads.auto.gke.io 1>/dev/null 2>/dev/null; then
+    false
+  else
+    IS_AUTOPILOT=1; readonly IS_AUTOPILOT
+  fi
+}

--- a/asmcli/lib/validate.sh
+++ b/asmcli/lib/validate.sh
@@ -165,6 +165,11 @@ EOF
 }
 
 validate_node_pool_workload_identity(){
+  # Autopilot clusters do not allow accessing/mutating the node pools
+  # so we skip in such cases.
+  if is_autopilot; then
+    return
+  fi
   local METADATA_CONFIG_MODE MACHINE_CPU_REQ
   # No CPU requirement for Managed ASM
   MACHINE_CPU_REQ=0

--- a/asmcli/tests/lib/validate.bats
+++ b/asmcli/tests/lib/validate.bats
@@ -39,3 +39,17 @@ setup() {
   run context_get-option "CLUSTER_LOCATION"
   assert_output "${GKE_CLUSTER_LOCATION}"
 }
+
+@test "VALIDATE: validate_node_pool_workload_identity should skip autopilot cluster" {
+  is_autopilot() {
+    true
+  }
+  run validate_node_pool_workload_identity
+  assert_success
+
+  is_autopilot() {
+    false
+  }
+  run validate_node_pool_workload_identity
+  assert_failure
+}


### PR DESCRIPTION
autopilot is causing failures since it does not allow access to the node pools. Skip autopilot clusters during validation.