### PR TITLE
`onlineboutique` - v0.3.5

### DIFF
--- a/samples/online-boutique/kubernetes-manifests/deployments/adservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/adservice.yaml
@@ -35,16 +35,16 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/adservice:v0.3.4
+          image: gcr.io/google-samples/microservices-demo/adservice:v0.3.5
           ports:
             - containerPort: 9555
           env:
             - name: PORT
               value: "9555"
-          # - name: DISABLE_STATS
-          #   value: "1"
-          # - name: DISABLE_TRACING
-          #   value: "1"
+            - name: DISABLE_STATS
+              value: "1"
+            - name: DISABLE_TRACING
+              value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
           resources:

--- a/samples/online-boutique/kubernetes-manifests/deployments/cartservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/cartservice.yaml
@@ -36,7 +36,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.5
         ports:
         - containerPort: 7070
         env:

--- a/samples/online-boutique/kubernetes-manifests/deployments/checkoutservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/checkoutservice.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: checkout
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.4
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.5
           ports:
           - containerPort: 5050
           readinessProbe:
@@ -59,12 +59,12 @@ spec:
             value: "currencyservice.currency.svc.cluster.local:7000"
           - name: CART_SERVICE_ADDR
             value: "cartservice.cart.svc.cluster.local:7070"
-          # - name: DISABLE_STATS
-          #   value: "1"
-          # - name: DISABLE_TRACING
-          #   value: "1"
-          # - name: DISABLE_PROFILER
-          #   value: "1"
+          - name: DISABLE_STATS
+            value: "1"
+          - name: DISABLE_TRACING
+            value: "1"
+          - name: DISABLE_PROFILER
+            value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
           resources:

--- a/samples/online-boutique/kubernetes-manifests/deployments/currencyservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/currencyservice.yaml
@@ -36,19 +36,19 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.5
         ports:
         - name: grpc
           containerPort: 7000
         env:
         - name: PORT
           value: "7000"
-        # - name: DISABLE_TRACING
-        #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
-        # - name: DISABLE_DEBUGGER
-        #   value: "1"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]

--- a/samples/online-boutique/kubernetes-manifests/deployments/emailservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/emailservice.yaml
@@ -35,14 +35,14 @@ spec:
       serviceAccountName: email
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.5
         ports:
         - containerPort: 8080
         env:
         - name: PORT
           value: "8080"
-        # - name: DISABLE_TRACING
-        #   value: "1"
+        - name: DISABLE_TRACING
+          value: "1"
         - name: DISABLE_PROFILER
           value: "1"
         readinessProbe:

--- a/samples/online-boutique/kubernetes-manifests/deployments/frontend.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/frontend.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: frontend
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.3.4
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.3.5
           ports:
           - containerPort: 8080
           readinessProbe:
@@ -77,10 +77,10 @@ spec:
           # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp 
           # - name: ENV_PLATFORM 
           #   value: "aws"
-          # - name: DISABLE_TRACING
-          #   value: "1"
-          # - name: DISABLE_PROFILER
-          #   value: "1"
+          - name: DISABLE_TRACING
+            value: "1"
+          - name: DISABLE_PROFILER
+            value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
           resources:

--- a/samples/online-boutique/kubernetes-manifests/deployments/loadgenerator.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/loadgenerator.yaml
@@ -39,7 +39,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: main
-        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.3.5
         env:
         - name: FRONTEND_ADDR
           value: "frontend.frontend.svc.cluster.local:80"

--- a/samples/online-boutique/kubernetes-manifests/deployments/paymentservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/paymentservice.yaml
@@ -36,12 +36,18 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.5
         ports:
         - containerPort: 50051
         env:
         - name: PORT
           value: "50051"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]

--- a/samples/online-boutique/kubernetes-manifests/deployments/productcatalogservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/productcatalogservice.yaml
@@ -36,18 +36,18 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.5
         ports:
         - containerPort: 3550
         env:
         - name: PORT
           value: "3550"
-        # - name: DISABLE_STATS
-        #   value: "1"
-        # - name: DISABLE_TRACING
-        #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
+        - name: DISABLE_STATS
+          value: "1"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
         # - name: JAEGER_SERVICE_ADDR
         #   value: "jaeger-collector:14268"
         readinessProbe:

--- a/samples/online-boutique/kubernetes-manifests/deployments/recommendationservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/recommendationservice.yaml
@@ -36,7 +36,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.5
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -52,12 +52,12 @@ spec:
           value: "8080"
         - name: PRODUCT_CATALOG_SERVICE_ADDR
           value: "productcatalogservice.product-catalog.svc.cluster.local:3550"
-        # - name: DISABLE_TRACING
-        #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
-        # - name: DISABLE_DEBUGGER
-        #   value: "1"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
         resources:
           requests:
             cpu: 100m

--- a/samples/online-boutique/kubernetes-manifests/deployments/shippingservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/shippingservice.yaml
@@ -35,18 +35,18 @@ spec:
       serviceAccountName: shipping
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.4
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.5
         ports:
         - containerPort: 50051
         env:
         - name: PORT
           value: "50051"
-        # - name: DISABLE_STATS
-        #   value: "1"
-        # - name: DISABLE_TRACING
-        #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
+        - name: DISABLE_STATS
+          value: "1"
+        - name: DISABLE_TRACING
+          value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
         # - name: JAEGER_SERVICE_ADDR
         #   value: "jaeger-collector:14268"
         readinessProbe:


### PR DESCRIPTION
Upgrade onlineboutique sample to v0.3.5 https://github.com/GoogleCloudPlatform/microservices-demo/releases/tag/v0.3.5

2 main reasons:
- Updated Log4j to 2.17.1
- Turned off GCP integration by default - which land to an issue if not here when deploying ASM on non-GKE-on-GCP clusters by following this doc: https://cloud.google.com/service-mesh/docs/onlineboutique-install-kpt