### PR TITLE
autopilot should default enable managed CNI

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -5263,6 +5263,13 @@ validate_args() {
       fatal "The --legacy option is only supported with managed control plane."
   fi
 
+  if is_autopilot; then
+    if ! is_managed; then
+      fatal "Autopilot clusters are only supported with managed control plane."
+    fi
+    context_set-option "USE_MANAGED_CNI" 1
+  fi
+
   if [[ -z "${CA}" ]]; then
     CA="mesh_ca"
     context_set-option "CA" "${CA}"

--- a/asmcli/lib/validate.sh
+++ b/asmcli/lib/validate.sh
@@ -559,6 +559,13 @@ validate_args() {
       fatal "The --legacy option is only supported with managed control plane."
   fi
 
+  if is_autopilot; then
+    if ! is_managed; then
+      fatal "Autopilot clusters are only supported with managed control plane."
+    fi
+    context_set-option "USE_MANAGED_CNI" 1
+  fi
+
   if [[ -z "${CA}" ]]; then
     CA="mesh_ca"
     context_set-option "CA" "${CA}"

--- a/asmcli/tests/unit_test_common.bash
+++ b/asmcli/tests/unit_test_common.bash
@@ -85,6 +85,10 @@ _intercept_setup() {
         fi
         return 0
     }
+
+    is_autopilot() {
+      false
+    }
 }
 
 gcloud_intercept() {


### PR DESCRIPTION
```
# without --use-managed-cni
./asmcli/asmcli install --kubeconfig ~/.kube/config  --managed -e -v  
...
2022-01-20T05:18:18.347866 asmcli: Running: '/tmp/tmp.5S59tHpKvC/kpt cfg set asm anthos.servicemesh.use-managed-cni true'
2022-01-20T05:18:18.415376 asmcli: -------------
asm/
set 3 field(s) of setter "anthos.servicemesh.use-managed-cni" to value "true"
...
```