### PR TITLE
Unset which

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -14,6 +14,12 @@ else
   set -u
 fi
 
+### Workaround for RHEL/centOS redefining which for whatever reason?
+
+if [[ -f /etc/profile.d/which2.sh ]]; then
+  unset -f which
+fi
+
 ### These are hooks for Cloud Build to be able to use debug/staging images
 ### when necessary. Don't set these environment variables unless you're testing
 ### in CI/CD.

--- a/asmcli/asmcli.sh
+++ b/asmcli/asmcli.sh
@@ -10,6 +10,12 @@ else
   set -u
 fi
 
+### Workaround for RHEL/centOS redefining which for whatever reason?
+
+if [[ -f /etc/profile.d/which2.sh ]]; then
+  unset -f which
+fi
+
 ### These are hooks for Cloud Build to be able to use debug/staging images
 ### when necessary. Don't set these environment variables unless you're testing
 ### in CI/CD.


### PR DESCRIPTION
RHEL for whatever reason now includes this by default and it breaks a lot of stuff, including asmcli.