### PR TITLE
Fix issue #1117

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1672,16 +1672,31 @@ expose_istiod() {
 
 outro() {
   local OUTPUT_DIR; OUTPUT_DIR="$(context_get-option "OUTPUT_DIR")"
-  
+  local CHANNEL; CHANNEL="$(context_get-option "CHANNEL")"
+  local MANAGED_REVISION_LABEL; MANAGED_REVISION_LABEL="${REVISION_LABEL}"
+  if is_managed; then
+    case "${CHANNEL}" in
+    regular)
+      MANAGED_REVISION_LABEL="${REVISION_LABEL_REGULAR}"
+      ;;
+    stable)
+      MANAGED_REVISION_LABEL="${REVISION_LABEL_STABLE}"
+      ;;
+    rapid)
+      MANAGED_REVISION_LABEL="${REVISION_LABEL_RAPID}"
+      ;;
+    esac
+  fi
+
   info ""
   info "$(starline)"
   istioctl version
   info "$(starline)"
   info "The ASM control plane installation is now complete."
   info "To enable automatic sidecar injection on a namespace, you can use the following command:"
-  info "kubectl label namespace <NAMESPACE> istio-injection- istio.io/rev=${REVISION_LABEL} --overwrite"
+  info "kubectl label namespace <NAMESPACE> istio-injection- istio.io/rev=${MANAGED_REVISION_LABEL} --overwrite"
   info "If you use 'istioctl install' afterwards to modify this installation, you will need"
-  info "to specify the option '--set revision=${REVISION_LABEL}' to target this control plane"
+  info "to specify the option '--set revision=${MANAGED_REVISION_LABEL}' to target this control plane"
   info "instead of installing a new one."
 
   info "To finish the installation, enable Istio sidecar injection and restart your workloads."

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1672,6 +1672,20 @@ expose_istiod() {
 
 outro() {
   local OUTPUT_DIR; OUTPUT_DIR="$(context_get-option "OUTPUT_DIR")"
+  local MANAGED_REVISION_LABEL; MANAGED_REVISION_LABEL="${REVISION_LABEL}"
+  if is_managed; then
+    case "${CHANNEL}" in
+    regular)
+      REVISION_LABEL="${REVISION_LABEL_REGULAR}"
+      ;;
+    stable)
+      REVISION_LABEL="${REVISION_LABEL_STABLE}"
+      ;;
+    rapid)
+      REVISION_LABEL="${REVISION_LABEL_RAPID}"
+      ;;
+    esac  
+  fi
 
   info ""
   info "$(starline)"
@@ -1679,9 +1693,9 @@ outro() {
   info "$(starline)"
   info "The ASM control plane installation is now complete."
   info "To enable automatic sidecar injection on a namespace, you can use the following command:"
-  info "kubectl label namespace <NAMESPACE> istio-injection- istio.io/rev=${REVISION_LABEL} --overwrite"
+  info "kubectl label namespace <NAMESPACE> istio-injection- istio.io/rev=${MANAGED_REVISION_LABEL} --overwrite"
   info "If you use 'istioctl install' afterwards to modify this installation, you will need"
-  info "to specify the option '--set revision=${REVISION_LABEL}' to target this control plane"
+  info "to specify the option '--set revision=${MANAGED_REVISION_LABEL}' to target this control plane"
   info "instead of installing a new one."
 
   info "To finish the installation, enable Istio sidecar injection and restart your workloads."

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1672,30 +1672,16 @@ expose_istiod() {
 
 outro() {
   local OUTPUT_DIR; OUTPUT_DIR="$(context_get-option "OUTPUT_DIR")"
-  local MANAGED_REVISION_LABEL; MANAGED_REVISION_LABEL="${REVISION_LABEL}"
-  if is_managed; then
-    case "${CHANNEL}" in
-    regular)
-      REVISION_LABEL="${REVISION_LABEL_REGULAR}"
-      ;;
-    stable)
-      REVISION_LABEL="${REVISION_LABEL_STABLE}"
-      ;;
-    rapid)
-      REVISION_LABEL="${REVISION_LABEL_RAPID}"
-      ;;
-    esac  
-  fi
-
+  
   info ""
   info "$(starline)"
   istioctl version
   info "$(starline)"
   info "The ASM control plane installation is now complete."
   info "To enable automatic sidecar injection on a namespace, you can use the following command:"
-  info "kubectl label namespace <NAMESPACE> istio-injection- istio.io/rev=${MANAGED_REVISION_LABEL} --overwrite"
+  info "kubectl label namespace <NAMESPACE> istio-injection- istio.io/rev=${REVISION_LABEL} --overwrite"
   info "If you use 'istioctl install' afterwards to modify this installation, you will need"
-  info "to specify the option '--set revision=${MANAGED_REVISION_LABEL}' to target this control plane"
+  info "to specify the option '--set revision=${REVISION_LABEL}' to target this control plane"
   info "instead of installing a new one."
 
   info "To finish the installation, enable Istio sidecar injection and restart your workloads."

--- a/asmcli/commands/install.sh
+++ b/asmcli/commands/install.sh
@@ -144,6 +144,21 @@ expose_istiod() {
 
 outro() {
   local OUTPUT_DIR; OUTPUT_DIR="$(context_get-option "OUTPUT_DIR")"
+  local CHANNEL; CHANNEL="$(context_get-option "CHANNEL")"
+  local MANAGED_REVISION_LABEL; MANAGED_REVISION_LABEL="${REVISION_LABEL}"
+  if is_managed; then
+    case "${CHANNEL}" in
+    regular)
+      MANAGED_REVISION_LABEL="${REVISION_LABEL_REGULAR}"
+      ;;
+    stable)
+      MANAGED_REVISION_LABEL="${REVISION_LABEL_STABLE}"
+      ;;
+    rapid)
+      MANAGED_REVISION_LABEL="${REVISION_LABEL_RAPID}"
+      ;;
+    esac
+  fi
 
   info ""
   info "$(starline)"
@@ -151,9 +166,9 @@ outro() {
   info "$(starline)"
   info "The ASM control plane installation is now complete."
   info "To enable automatic sidecar injection on a namespace, you can use the following command:"
-  info "kubectl label namespace <NAMESPACE> istio-injection- istio.io/rev=${REVISION_LABEL} --overwrite"
+  info "kubectl label namespace <NAMESPACE> istio-injection- istio.io/rev=${MANAGED_REVISION_LABEL} --overwrite"
   info "If you use 'istioctl install' afterwards to modify this installation, you will need"
-  info "to specify the option '--set revision=${REVISION_LABEL}' to target this control plane"
+  info "to specify the option '--set revision=${MANAGED_REVISION_LABEL}' to target this control plane"
   info "instead of installing a new one."
 
   info "To finish the installation, enable Istio sidecar injection and restart your workloads."


### PR DESCRIPTION
Fix issue #1117 : We print out the revision label in the outro, but we don't change the revision label based on the type of installation has been launched. For instance, --managed with --channel rapid should return --asm-managed-rapid, asm-managed is return instead.