### PR TITLE
asmcli should respect CNI=off

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -2315,7 +2315,7 @@ install_mananged_cni_static() {
     get --ignore-not-found cm asm-options \
     -o jsonpath='{.data.ASM_OPTS}' || true)"
 
-  if [[ -z "${ASM_OPTS}" || "${ASM_OPTS}" != *"CNI=on"* ]]; then
+  if [[ -z "${ASM_OPTS}" || "${ASM_OPTS}" != *"CNI=on"* && "${ASM_OPTS}" != *"CNI=off"* ]]; then
     context_append "mcpOptions" "CNI=on"
   else
     context_append "mcpOptions" "${ASM_OPTS}"

--- a/asmcli/components/control-plane/managed.sh
+++ b/asmcli/components/control-plane/managed.sh
@@ -127,7 +127,7 @@ install_mananged_cni_static() {
     get --ignore-not-found cm asm-options \
     -o jsonpath='{.data.ASM_OPTS}' || true)"
 
-  if [[ -z "${ASM_OPTS}" || "${ASM_OPTS}" != *"CNI=on"* ]]; then
+  if [[ -z "${ASM_OPTS}" || "${ASM_OPTS}" != *"CNI=on"* && "${ASM_OPTS}" != *"CNI=off"* ]]; then
     context_append "mcpOptions" "CNI=on"
   else
     context_append "mcpOptions" "${ASM_OPTS}"


### PR DESCRIPTION
install asm and cat the applied configmap in the output directory
```
cat /tmp/tmp.coZvKvhKvj/mcp_configmap.yaml 
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: asm-options
  namespace: istio-system
data:
  ASM_OPTS: "CNI=on;"
```

update the config map in the cluster to be `CNI=off`
```
k edit cm asm-options -n istio-system
configmap/asm-options edited
```

install and cat again
```
cat /tmp/tmp.coZvKvhKvj/mcp_configmap.yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: asm-options
  namespace: istio-system
data:
  ASM_OPTS: "CNI=off;;"
```

Double-check the in-cluster CM
```
k get cm asm-options -n istio-system -oyaml
apiVersion: v1
data:
  ASM_OPTS: CNI=off;;
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"ASM_OPTS":"CNI=off;;"},"kind":"ConfigMap","metadata":{"annotations":{},"name":"asm-options","namespace":"istio-system"}}
  creationTimestamp: "2022-01-12T22:32:52Z"
  name: asm-options
  namespace: istio-system
  resourceVersion: "34477384"
  uid: 0c545db0-dc14-4f59-ba09-27486dad9002
```

there's an issue with the semi-colon when the options are re-applied, but shouldn't affect much. 