### PR TITLE
skip cni install if node pool wi is not enabled

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -151,6 +151,12 @@ openAPI:
         setter:
           name: anthos.servicemesh.managed-controlplane.cloudrun-addr
           value: CLOUDRUN_ADDR
+    io.k8s.cli.setters.anthos.servicemesh.managed-cni.cni-enable-install:
+      type: string
+      x-k8s-cli:
+        setter:
+          name: anthos.servicemesh.managed-cni.cni-enable-install
+          value: "true"
     io.k8s.cli.substitutions.mesh-id:
       type: string
       x-k8s-cli:

--- a/asm/istio/options/cni-managed.yaml
+++ b/asm/istio/options/cni-managed.yaml
@@ -362,6 +362,8 @@ spec:
             port: 8000
         command: ["install-cni"]
         env:
+        - name: CNI_ENABLE_INSTALL
+          value: "true"  # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.managed-cni.cni-enable-install"}
         # The CNI network config to install on each node.
         - name: CNI_NETWORK_CONFIG
           valueFrom:

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -96,6 +96,7 @@ RAW_YAML=""
 EXPANDED_YAML=""
 NAMESPACE_EXISTS=0
 IS_AUTOPILOT=0
+NODE_POOL_WI_ENABLED=0
 
 main() {
   if [[ "${*}" = '' ]]; then
@@ -1912,17 +1913,34 @@ validate_dependencies() {
 }
 
 validate_control_plane() {
-  if is_managed; then
+  if is_autopilot; then
+    validate_autopilot
+  elif is_managed; then
     if is_legacy; then
       # Managed legacy must be able to set IAM permissions on a generated user, so the flow
       # is a bit different
       validate_managed_control_plane_legacy
     fi
-    # Node-level Workload Identity is required for managed CNI
-    validate_node_pool_workload_identity
   else
     validate_in_cluster_control_plane
   fi
+}
+
+validate_autopilot() {
+  if ! is_managed; then
+    fatal "Autopilot clusters are only supported with managed control plane."
+  fi
+  if is_legacy; then
+    fatal "Autopilot clusters are not supported with legacy managed control plane."
+  fi
+  # Autopilot requires managed CNI
+  local USE_MANAGED_CNI; USE_MANAGED_CNI="$(context_get-option "USE_MANAGED_CNI")"
+  if [[ "${USE_MANAGED_CNI}" -eq 0 ]]; then
+    warn "Managed CNI is required to continue installing managed ASM on GKE Autopilot."
+    warn "Confirm or pass --use-managed-cni flag to asmcli."
+    if ! prompt_default_no "Continue?"; then fatal "Stopping installation at user request."; fi
+  fi
+  context_set-option "USE_MANAGED_CNI" 1
 }
 validate_custom_ca() {
   local CA_ROOT; CA_ROOT="$(context_get-option "CA_ROOT")"
@@ -2228,7 +2246,7 @@ install_managed_control_plane() {
   fi
 
   if [[ "${USE_MANAGED_CNI}" -eq 0 ]]; then
-    install_mananged_cni_static
+    install_managed_cni_static
   fi
 
   if [[ "${CA}" = "gcp_cas" ]]; then
@@ -2315,8 +2333,18 @@ EOF
 
 }
 
-install_mananged_cni_static() {
+install_managed_cni_static() {
   info "Configuring CNI..."
+  if ! node_pool_wi_enabled; then
+  { read -r -d '' MSG; warn_pause "${MSG}"; } <<EOF || true
+
+Nodepool Workload identity is not enabled or only partially enabled. CNI components will be installed but won't be used.
+To use CNI, please follow:
+  https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#migrate_applications_to 
+to migrate or update to a Workload Identity Enabled Node pool.
+
+EOF
+  fi
   local ASM_OPTS
   ASM_OPTS="$(kubectl -n istio-system \
     get --ignore-not-found cm asm-options \
@@ -2856,6 +2884,34 @@ is_autopilot() {
     IS_AUTOPILOT=1; readonly IS_AUTOPILOT
   fi
 }
+
+node_pool_wi_enabled(){
+  # Autopilot clusters do not allow accessing/mutating the node pools
+  # so we skip in such cases.
+  if is_autopilot || [[ "${NODE_POOL_WI_ENABLED}" -eq 1 ]]; then 
+    return
+  fi
+  local METADATA_CONFIG_MODE MACHINE_CPU_REQ
+  # No CPU requirement for Managed ASM
+  MACHINE_CPU_REQ=0
+  METADATA_CONFIG_MODE="$(list_valid_pools "${MACHINE_CPU_REQ}" | \
+      jq -r '.[] |
+        .config.workloadMetadataConfig.mode
+      ' 2>/dev/null)" || true
+  if [[ -z "${METADATA_CONFIG_MODE}" ]]; then
+    NODE_POOL_WI_ENABLED=0
+    false
+    return
+  fi
+  for metadata in ${METADATA_CONFIG_MODE}; do
+    if [[ "${metadata}" != "GKE_METADATA" ]]; then
+      NODE_POOL_WI_ENABLED=0
+      false
+      return
+    fi
+  done
+  NODE_POOL_WI_ENABLED=1; readonly NODE_POOL_WI_ENABLED
+}
 configure_package() {
   local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
   local CLUSTER_NAME; CLUSTER_NAME="$(context_get-option "CLUSTER_NAME")"
@@ -2927,6 +2983,9 @@ configure_package() {
 
   if [[ "${USE_MANAGED_CNI}" -eq 1 ]]; then
     kpt cfg set asm anthos.servicemesh.use-managed-cni "true"
+  fi
+  if ! node_pool_wi_enabled; then
+    kpt cfg set asm anthos.servicemesh.managed-cni.cni-enable-install "false"
   fi
   if [[ "${USE_VPCSC}" -eq 1 ]]; then
     kpt cfg set asm anthos.servicemesh.managed-controlplane.vpcsc.enabled "true"
@@ -5074,30 +5133,6 @@ EOF
   fi
 }
 
-validate_node_pool_workload_identity(){
-  # Autopilot clusters do not allow accessing/mutating the node pools
-  # so we skip in such cases.
-  if is_autopilot; then
-    return
-  fi
-  local METADATA_CONFIG_MODE MACHINE_CPU_REQ
-  # No CPU requirement for Managed ASM
-  MACHINE_CPU_REQ=0
-  METADATA_CONFIG_MODE="$(list_valid_pools "${MACHINE_CPU_REQ}" | \
-      jq -r '.[] |
-        .config.workloadMetadataConfig.mode
-      ' 2>/dev/null)" || true
-  if [[ "${METADATA_CONFIG_MODE}" != "GKE_METADATA" ]]; then
-    { read -r -d '' MSG; validation_error "${MSG}"; } <<EOF || true
-Node pool Workload Identity is not enabled which is a pre-requisite for Managed ASM.
-Please follow:
-  https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#migrate_applications_to 
-to migrate or update to a Workload Identity Enabled Node pool. 
-If installation continues, Managed ASM components such as CNI will not work properly.
-EOF
-  fi
-}
-
 validate_expected_control_plane(){
   info "Checking Istio installations..."
   check_no_istiod_outside_of_istio_system_namespace
@@ -5477,13 +5512,6 @@ validate_args() {
 
   if is_legacy && ! is_managed; then
       fatal "The --legacy option is only supported with managed control plane."
-  fi
-
-  if is_autopilot; then
-    if ! is_managed; then
-      fatal "Autopilot clusters are only supported with managed control plane."
-    fi
-    context_set-option "USE_MANAGED_CNI" 1
   fi
 
   if [[ -z "${CA}" ]]; then

--- a/asmcli/asmcli.sh
+++ b/asmcli/asmcli.sh
@@ -92,6 +92,7 @@ RAW_YAML=""
 EXPANDED_YAML=""
 NAMESPACE_EXISTS=0
 IS_AUTOPILOT=0
+NODE_POOL_WI_ENABLED=0
 
 main() {
   if [[ "${*}" = '' ]]; then

--- a/asmcli/commands/validate.sh
+++ b/asmcli/commands/validate.sh
@@ -91,15 +91,32 @@ validate_dependencies() {
 }
 
 validate_control_plane() {
-  if is_managed; then
+  if is_autopilot; then
+    validate_autopilot
+  elif is_managed; then
     if is_legacy; then
       # Managed legacy must be able to set IAM permissions on a generated user, so the flow
       # is a bit different
       validate_managed_control_plane_legacy
     fi
-    # Node-level Workload Identity is required for managed CNI
-    validate_node_pool_workload_identity
   else
     validate_in_cluster_control_plane
   fi
+}
+
+validate_autopilot() {
+  if ! is_managed; then
+    fatal "Autopilot clusters are only supported with managed control plane."
+  fi
+  if is_legacy; then
+    fatal "Autopilot clusters are not supported with legacy managed control plane."
+  fi
+  # Autopilot requires managed CNI
+  local USE_MANAGED_CNI; USE_MANAGED_CNI="$(context_get-option "USE_MANAGED_CNI")"
+  if [[ "${USE_MANAGED_CNI}" -eq 0 ]]; then
+    warn "Managed CNI is required to continue installing managed ASM on GKE Autopilot."
+    warn "Confirm or pass --use-managed-cni flag to asmcli."
+    if ! prompt_default_no "Continue?"; then fatal "Stopping installation at user request."; fi
+  fi
+  context_set-option "USE_MANAGED_CNI" 1
 }

--- a/asmcli/components/control-plane/managed.sh
+++ b/asmcli/components/control-plane/managed.sh
@@ -33,7 +33,7 @@ install_managed_control_plane() {
   fi
 
   if [[ "${USE_MANAGED_CNI}" -eq 0 ]]; then
-    install_mananged_cni_static
+    install_managed_cni_static
   fi
 
   if [[ "${CA}" = "gcp_cas" ]]; then
@@ -120,8 +120,18 @@ EOF
 
 }
 
-install_mananged_cni_static() {
+install_managed_cni_static() {
   info "Configuring CNI..."
+  if ! node_pool_wi_enabled; then
+  { read -r -d '' MSG; warn_pause "${MSG}"; } <<EOF || true
+
+Nodepool Workload identity is not enabled or only partially enabled. CNI components will be installed but won't be used.
+To use CNI, please follow:
+  https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#migrate_applications_to 
+to migrate or update to a Workload Identity Enabled Node pool.
+
+EOF
+  fi
   local ASM_OPTS
   ASM_OPTS="$(kubectl -n istio-system \
     get --ignore-not-found cm asm-options \

--- a/asmcli/lib/config.sh
+++ b/asmcli/lib/config.sh
@@ -70,6 +70,9 @@ configure_package() {
   if [[ "${USE_MANAGED_CNI}" -eq 1 ]]; then
     kpt cfg set asm anthos.servicemesh.use-managed-cni "true"
   fi
+  if ! node_pool_wi_enabled; then
+    kpt cfg set asm anthos.servicemesh.managed-cni.cni-enable-install "false"
+  fi
   if [[ "${USE_VPCSC}" -eq 1 ]]; then
     kpt cfg set asm anthos.servicemesh.managed-controlplane.vpcsc.enabled "true"
   fi

--- a/asmcli/lib/validate.sh
+++ b/asmcli/lib/validate.sh
@@ -164,30 +164,6 @@ EOF
   fi
 }
 
-validate_node_pool_workload_identity(){
-  # Autopilot clusters do not allow accessing/mutating the node pools
-  # so we skip in such cases.
-  if is_autopilot; then
-    return
-  fi
-  local METADATA_CONFIG_MODE MACHINE_CPU_REQ
-  # No CPU requirement for Managed ASM
-  MACHINE_CPU_REQ=0
-  METADATA_CONFIG_MODE="$(list_valid_pools "${MACHINE_CPU_REQ}" | \
-      jq -r '.[] |
-        .config.workloadMetadataConfig.mode
-      ' 2>/dev/null)" || true
-  if [[ "${METADATA_CONFIG_MODE}" != "GKE_METADATA" ]]; then
-    { read -r -d '' MSG; validation_error "${MSG}"; } <<EOF || true
-Node pool Workload Identity is not enabled which is a pre-requisite for Managed ASM.
-Please follow:
-  https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#migrate_applications_to 
-to migrate or update to a Workload Identity Enabled Node pool. 
-If installation continues, Managed ASM components such as CNI will not work properly.
-EOF
-  fi
-}
-
 validate_expected_control_plane(){
   info "Checking Istio installations..."
   check_no_istiod_outside_of_istio_system_namespace
@@ -567,13 +543,6 @@ validate_args() {
 
   if is_legacy && ! is_managed; then
       fatal "The --legacy option is only supported with managed control plane."
-  fi
-
-  if is_autopilot; then
-    if ! is_managed; then
-      fatal "Autopilot clusters are only supported with managed control plane."
-    fi
-    context_set-option "USE_MANAGED_CNI" 1
   fi
 
   if [[ -z "${CA}" ]]; then

--- a/asmcli/tests/lib/validate.bats
+++ b/asmcli/tests/lib/validate.bats
@@ -40,16 +40,19 @@ setup() {
   assert_output "${GKE_CLUSTER_LOCATION}"
 }
 
-@test "VALIDATE: validate_node_pool_workload_identity should skip autopilot cluster" {
+@test "VALIDATE: node_pool_wi_enabled should skip autopilot cluster" {
   is_autopilot() {
     true
   }
-  run validate_node_pool_workload_identity
-  assert_success
+
+  local RETVAL=0
+  _="$(node_pool_wi_enabled)" || RETVAL="${?}"
+  [ "${RETVAL}" -eq 0 ]
 
   is_autopilot() {
     false
   }
-  run validate_node_pool_workload_identity
-  assert_failure
+
+  _="$(node_pool_wi_enabled)" || RETVAL="${?}"
+  [ "${RETVAL}" -eq 1 ]
 }


### PR DESCRIPTION
This PR fixes 2 bugs and changes 1 behavior
1. it fixes the bug when the function `is_autopilot` is called too early to always return an error. If `asmcli` detects the cluster is autopilot, it shouldn't ever attempt to apply anything to the `kube-system`. It should always use managed CNI. The user shouldn't need to supply the `--use_managed_cni` flag. I moved that function to the `validate_control_plane` and refactored the validation for autopilot.
2. it fixes the bug that when we check for the node pool WI, we assumed only 1 node pool is present. It would directly fail on clusters with multiple node pools. Changed it to be a loop.
3. it changes the behavior that when the user's cluster does not have node pool WI enabled, it shouldn't just abort. It would set the env var in the `install-cni` container to skip the installation, and give a warning only. The env var is added with https://github.com/istio/istio/pull/38158