### PR TITLE
Fix name of istio remote secret for GKE cluster.

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -423,10 +423,8 @@ install_one_remote_secret() {
   SECRET_NAME="${CTX1//_/-}"
   SECRET_NAME="${SECRET_NAME//\./-}"
   SECRET_NAME="${SECRET_NAME//@/-}"
-  if [[ "${SECRET_NAME}" =~ ^gke_[^_]+_[^_]+_.+ ]]; then
-    local CTX_PROJECT CTX_LOCATION CTX_CLUSTER
-    IFS="_" read -r _ CTX_PROJECT CTX_LOCATION CTX_CLUSTER <<<"$(context_get-option "CONTEXT")"
-    SECRET_NAME="cn-${CTX_PROJECT}-${CTX_LOCATION}-${CTX_CLUSTER}"
+  if [[ "${CTX1}" =~ ^gke_[^_]+_[^_]+_.+ ]]; then
+    SECRET_NAME="${SECRET_NAME/#gke-/cn-}"
   fi
   SECRET_NAME="$(generate_secret_name "${SECRET_NAME}")"
 

--- a/asmcli/commands/create-mesh.sh
+++ b/asmcli/commands/create-mesh.sh
@@ -190,10 +190,8 @@ install_one_remote_secret() {
   SECRET_NAME="${CTX1//_/-}"
   SECRET_NAME="${SECRET_NAME//\./-}"
   SECRET_NAME="${SECRET_NAME//@/-}"
-  if [[ "${SECRET_NAME}" =~ ^gke_[^_]+_[^_]+_.+ ]]; then
-    local CTX_PROJECT CTX_LOCATION CTX_CLUSTER
-    IFS="_" read -r _ CTX_PROJECT CTX_LOCATION CTX_CLUSTER <<<"$(context_get-option "CONTEXT")"
-    SECRET_NAME="cn-${CTX_PROJECT}-${CTX_LOCATION}-${CTX_CLUSTER}"
+  if [[ "${CTX1}" =~ ^gke_[^_]+_[^_]+_.+ ]]; then
+    SECRET_NAME="${SECRET_NAME/#gke-/cn-}"
   fi
   SECRET_NAME="$(generate_secret_name "${SECRET_NAME}")"
 


### PR DESCRIPTION
This PR fixes name of istio remote secret created by `asmcli create-mesh` subcommand.

In using multicluster service mesh, inter-cluster routing by `topology.istio.io/cluster` label in DestinationRule does not work. It causes HTTP 503 response with `no healthy upstream`.
This problem seems caused by mismatch between cluster name and istio remote secret name.

Cluster name is generated by `asmcli install` subcommand and it is form as `cn-PROJECT_ID-LOCATION-CLUSTER_NAME`.
But, for name of istio remote secret generated by `asmcli create-mesh` subcommand, it forms `istio-remote-secret-gke-PROJEC_ID-LOCATION-CLUSTER_NAME`.

This PR changes `SECRET_NAME` as `cn-PROJECT_ID-LOCATION-CLUSTER_NAME` form if remote cluster is GKE.