### PR TITLE
fix the bug to not set the cni=on if no nodepoll WI

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -2348,7 +2348,7 @@ EOF
     get --ignore-not-found cm asm-options \
     -o jsonpath='{.data.ASM_OPTS}' || true)"
 
-  if [[ -z "${ASM_OPTS}" || "${ASM_OPTS}" != *"CNI=on"* && "${ASM_OPTS}" != *"CNI=off"* ]]; then
+if node_pool_wi_enabled && [[ -z "${ASM_OPTS}" || "${ASM_OPTS}" != *"CNI=on"* && "${ASM_OPTS}" != *"CNI=off"* ]]; then
     context_append "mcpOptions" "CNI=on"
   else
     context_append "mcpOptions" "${ASM_OPTS}"

--- a/asmcli/components/control-plane/managed.sh
+++ b/asmcli/components/control-plane/managed.sh
@@ -137,7 +137,7 @@ EOF
     get --ignore-not-found cm asm-options \
     -o jsonpath='{.data.ASM_OPTS}' || true)"
 
-  if [[ -z "${ASM_OPTS}" || "${ASM_OPTS}" != *"CNI=on"* && "${ASM_OPTS}" != *"CNI=off"* ]]; then
+if node_pool_wi_enabled && [[ -z "${ASM_OPTS}" || "${ASM_OPTS}" != *"CNI=on"* && "${ASM_OPTS}" != *"CNI=off"* ]]; then
     context_append "mcpOptions" "CNI=on"
   else
     context_append "mcpOptions" "${ASM_OPTS}"


### PR DESCRIPTION
Manual test result on a cluster without Nodepool WI. Note that CNI=on is not set.
```
2022-05-03T21:24:01.031694 asmcli: *****************************
2022-05-03T21:24:01.111655 asmcli: Successfully installed ASM.
➜  k get cm asm-options -n istio-system -oyaml
apiVersion: v1
data:
  ASM_OPTS: ""
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"ASM_OPTS":""},"kind":"ConfigMap","metadata":{"annotations":{},"name":"asm-options","namespace":"istio-system"}}
  creationTimestamp: "2022-05-03T21:23:53Z"
  name: asm-options
  namespace: istio-system
  resourceVersion: "14060028"
  uid: fd2a43fd-fd09-4db2-85bd-73bb086a4dc4
```