### PR TITLE
bind the required iam roles before registration

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -3303,6 +3303,19 @@ required_iam_roles() {
 }
 # [END required_iam_roles]
 
+# Required IAM roles for GKE Hub registratinon are
+# defined in https://cloud.google.com/anthos/fleet-management/docs/before-you-begin#grant_iam_roles
+required_iam_roles_registration() {
+  if is_gcp; then
+    echo roles/container.admin
+  else
+    echo roles/iam.serviceAccountAdmin
+    echo roles/iam.serviceAccountKeyAdmin
+    echo roles/resourcemanager.projectIamAdmin
+  fi
+  echo roles/gkehub.admin
+}
+
 old_required_apis() {
   local CA; CA="$(context_get-option "CA")"
     cat << EOF
@@ -3568,6 +3581,12 @@ register_cluster() {
     else
       exit_if_no_workload_identity
     fi
+  fi
+
+  if can_modify_gcp_iam_roles; then
+    bind_user_to_iam_policy "$(required_iam_roles_registration)" "$(local_iam_user)"
+  else
+    exit_if_out_of_iam_policy
   fi
   populate_cluster_values
 

--- a/asmcli/lib/installation_dependencies.sh
+++ b/asmcli/lib/installation_dependencies.sh
@@ -43,6 +43,19 @@ required_iam_roles() {
 }
 # [END required_iam_roles]
 
+# Required IAM roles for GKE Hub registratinon are
+# defined in https://cloud.google.com/anthos/fleet-management/docs/before-you-begin#grant_iam_roles
+required_iam_roles_registration() {
+  if is_gcp; then
+    echo roles/container.admin
+  else
+    echo roles/iam.serviceAccountAdmin
+    echo roles/iam.serviceAccountKeyAdmin
+    echo roles/resourcemanager.projectIamAdmin
+  fi
+  echo roles/gkehub.admin
+}
+
 old_required_apis() {
   local CA; CA="$(context_get-option "CA")"
     cat << EOF
@@ -308,6 +321,12 @@ register_cluster() {
     else
       exit_if_no_workload_identity
     fi
+  fi
+
+  if can_modify_gcp_iam_roles; then
+    bind_user_to_iam_policy "$(required_iam_roles_registration)" "$(local_iam_user)"
+  else
+    exit_if_out_of_iam_policy
   fi
   populate_cluster_values
 


### PR DESCRIPTION
```
Error from server (Forbidden): error when creating "STDIN": clusterrolebindings.rbac.authorization.k8s.io is forbidden: User "xxx@xxx.com" cannot create resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope: requires one of ["container.clusterRoleBindings.create"] permission(s).

```

If I don't have container.admin role, I won't be able to register the cluster. This PR binds the IAM roles required to register before the registration. The roles are taken directly from https://cloud.google.com/anthos/fleet-management/docs/before-you-begin#grant_iam_roles