### PR TITLE
ca migration trustDomain Alias fix

### DIFF
--- a/asm/istio/options/ca-migration-meshca.yaml
+++ b/asm/istio/options/ca-migration-meshca.yaml
@@ -25,5 +25,5 @@ spec:
     defaultConfig:
       proxyMetadata:
         PROXY_CONFIG_XDS_AGENT: "true"
-    trustDomainAliases: # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.trustDomainAliases"}
+    trustDomainAliases:
       - "cluster.local"


### PR DESCRIPTION
kpt configurations should not modify this option file which is intended to be appended to the list of trustDomains trusted by the control plane