### PR TITLE
Gateways samples - unprivileged container

### DIFF
--- a/samples/gateways/istio-egressgateway/deployment.yaml
+++ b/samples/gateways/istio-egressgateway/deployment.yaml
@@ -31,8 +31,20 @@ spec:
         app: istio-egressgateway
         istio: egressgateway
     spec:
+      securityContext:
+        fsGroup: 1337
+        runAsGroup: 1337
+        runAsNonRoot: true
+        runAsUser: 1337
       containers:
       - name: istio-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+          privileged: false
+          readOnlyRootFilesystem: true
         image: auto # The image will automatically update each time the pod starts.
         resources:
           limits:

--- a/samples/gateways/istio-egressgateway/service.yaml
+++ b/samples/gateways/istio-egressgateway/service.yaml
@@ -24,8 +24,10 @@ spec:
   # Any ports exposed in Gateway resources should be exposed here.
   - name: http2
     port: 80
+    targetPort: 8080
   - name: https
     port: 443
+    targetPort: 8443
   selector:
     istio: egressgateway
     app: istio-egressgateway

--- a/samples/gateways/istio-ingressgateway/deployment.yaml
+++ b/samples/gateways/istio-ingressgateway/deployment.yaml
@@ -32,8 +32,20 @@ spec:
         app: istio-ingressgateway
         istio: ingressgateway
     spec:
+      securityContext:
+        fsGroup: 1337
+        runAsGroup: 1337
+        runAsNonRoot: true
+        runAsUser: 1337
       containers:
       - name: istio-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+          privileged: false
+          readOnlyRootFilesystem: true
         image: auto # The image will automatically update each time the pod starts.
         resources:
           limits:

--- a/samples/gateways/istio-ingressgateway/service.yaml
+++ b/samples/gateways/istio-ingressgateway/service.yaml
@@ -28,8 +28,10 @@ spec:
   # Any ports exposed in Gateway resources should be exposed here.
   - name: http2
     port: 80
+    targetPort: 8080
   - name: https
     port: 443
+    targetPort: 8443
   selector:
     istio: ingressgateway
     app: istio-ingressgateway


### PR DESCRIPTION
Add back the unprivileged container setup for both ingress and egress gateways. This was originally here and was removed since [this PR](https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/pull/979).

This PR updates the `Deployments` with [`securityContext` features](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) as well as the `Services` in order to use non-privilege ports on the container (`8443` and `8080`). With that we have more security features by default with these samples. Also, it allows these samples to run on any restricted and secured environment (think PSP, OpenShift, etc.).