### PR TITLE
Wait for workload certificate enablement

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1876,8 +1876,7 @@ validate_dependencies() {
         enable_service_mesh_feature
       fi
       if [[ "${CA}" == "managed_cas" ]]; then
-        info "Wait 3 minutes for GKE HUB API enablement to propagate to the systems ..."
-        sleep 180
+        x_wait_for_gke_hub_api_enablement
         x_enable_workload_certificate_on_fleet "gkehub.googleapis.com"
       fi
     else
@@ -2137,51 +2136,56 @@ x_enable_workload_certificate_on_membership() {
      -d "${ENABLEFEATURE}" "https://${GKEHUB_API}/v1alpha/projects/${FLEET_ID}/locations/global/features/workloadcertificate?update_mask=membership_specs"
 }
 
+x_wait_for_gke_hub_api_enablement() {
+  info "Wait 3 minutes for GKE HUB API enablement to propagate to the systems ..."
+  sleep 180
+}
+
 x_wait_for_enabling_workload_certificates() {
   local GKEHUB_API; GKEHUB_API="$1"
   local FLEET_ID; FLEET_ID="$2"
 
   info "Waiting for the workload certificates enablement. This may take up to 20 minutes ..."
-  # Enabling workload certificate feature on a cluster will result in
-  # the cluster restarting and the cluster becoming unreachable for minutes.
-  # The cluster restart may happen at a random time after the enablement.
-  # Therefore, wait 15 minutes before checking the connection to k8s is recovered.
-  sleep 900
-  # Check the connection to k8s is recovered.
-  local REACHABLE; REACHABLE=false
-  for i in {1..3}; do
-    local OUT; OUT=$(kubectl version -o json 2>/dev/null | jq .serverVersion.major -r 2>/dev/null)
-    if [[ $OUT -eq 1 ]]; then
-      info "The k8s cluster is reachable."
-      REACHABLE=true
-      break
-    else
-      info "The k8s cluster not reachable, try again ..."
-      sleep 60
-    fi
-  done
-  if ! $REACHABLE; then
-    fatal "The k8s cluster is not reachable, exit."
-  fi
-
   # Check the status of workload certificate feature
-  local ENABLED; ENABLED=false
+  local ENABLED; ENABLED=0
   for i in {1..2}; do
     local OUT; OUT="$(curl -H "X-Goog-User-Project: ${FLEET_ID}" \
       -H "Authorization: Bearer $(gcloud auth print-access-token)" \
       "https://${GKEHUB_API}/v1alpha/projects/${FLEET_ID}/locations/global/features/workloadcertificate" 2>/dev/null | \
-      grep -i -c "certificateManagement.*ENABLED")"
-    if [[ $OUT -gt 0 ]]; then
+      grep -i "certificateManagement.*ENABLED")"
+    if [[ -z "$OUT" ]]; then
       info "Workload certificate management is enabled."
-      ENABLED=true
+      ENABLED=1
       break
     else
       info "Workload certificate management is not enabled, try again ..."
       sleep 60
     fi
   done
-  if ! $ENABLED; then
+  if [[ "${ENABLED}" -eq 0 ]]; then
     warn "The workload certificate management is not enabled. The workload certificates may not work until the management is enabled."
+  fi
+
+  # Enabling workload certificate feature on a cluster will result in
+  # the cluster restarting and the cluster becoming unreachable for minutes.
+  # The cluster restart may happen at a random time after the enablement.
+  # Therefore, wait 15 minutes before checking the connection to k8s is recovered.
+  sleep 900
+  # Check the connection to k8s is recovered.
+  local REACHABLE; REACHABLE=0
+  for i in {1..3}; do
+    local OUT; OUT=$(kubectl version -o json 2>/dev/null | jq .serverVersion.major -r 2>/dev/null)
+    if [[ $OUT -eq 1 ]]; then
+      info "The k8s cluster is reachable."
+      REACHABLE=1
+      break
+    else
+      info "The k8s cluster not reachable, try again ..."
+      sleep 60
+    fi
+  done
+  if [[ "${REACHABLE}" -eq 0 ]]; then
+    fatal "The k8s cluster is not reachable, exit."
   fi
 }
 

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -2174,18 +2174,18 @@ x_wait_for_enabling_workload_certificates() {
   # Check the connection to k8s is recovered.
   local REACHABLE; REACHABLE=0
   for i in {1..3}; do
-    local OUT; OUT=$(kubectl version -o json 2>/dev/null | jq .serverVersion.major -r 2>/dev/null)
-    if [[ $OUT -eq 1 ]]; then
-      info "The k8s cluster is reachable."
+    local OUT; OUT=$(kubectl get ds -n kube-system gke-spiffe-node-agent 2>/dev/null | grep -i "gke-spiffe-node-agent")
+    if [[ -z "$OUT" ]]; then
+      info "The k8s cluster is reachable and gke-spiffe-node-agent is found."
       REACHABLE=1
       break
     else
-      info "The k8s cluster not reachable, try again ..."
+      info "The k8s cluster is not reachable or gke-spiffe-node-agent is not found, try again ..."
       sleep 60
     fi
   done
   if [[ "${REACHABLE}" -eq 0 ]]; then
-    fatal "The k8s cluster is not reachable, exit."
+    fatal "The k8s cluster is not reachable or gke-spiffe-node-agent is not found, exit."
   fi
 }
 

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -1876,6 +1876,8 @@ validate_dependencies() {
         enable_service_mesh_feature
       fi
       if [[ "${CA}" == "managed_cas" ]]; then
+        info "Wait 3 minutes for GKE HUB API enablement to propagate to the systems ..."
+        sleep 180
         x_enable_workload_certificate_on_fleet "gkehub.googleapis.com"
       fi
     else
@@ -1894,6 +1896,7 @@ validate_dependencies() {
     local HUB_MEMBERSHIP_ID; HUB_MEMBERSHIP_ID="$(context_get-option "HUB_MEMBERSHIP_ID")"
     if [[ "${CA}" == "managed_cas" ]]; then
       x_enable_workload_certificate_on_membership "gkehub.googleapis.com" "${FLEET_ID}" "${HUB_MEMBERSHIP_ID}"
+      x_wait_for_enabling_workload_certificates "gkehub.googleapis.com" "${FLEET_ID}"
     fi
   elif should_validate && [[ "${USE_HUB_WIP}" -eq 1 || "${USE_VM}" -eq 1 ]]; then
     exit_if_cluster_unregistered
@@ -2132,6 +2135,54 @@ x_enable_workload_certificate_on_membership() {
   curl -H "Authorization: Bearer ${AUTHTOKEN}" \
      -X PATCH -H "Content-Type: application/json" -H "Accept: application/json" \
      -d "${ENABLEFEATURE}" "https://${GKEHUB_API}/v1alpha/projects/${FLEET_ID}/locations/global/features/workloadcertificate?update_mask=membership_specs"
+}
+
+x_wait_for_enabling_workload_certificates() {
+  local GKEHUB_API; GKEHUB_API="$1"
+  local FLEET_ID; FLEET_ID="$2"
+
+  info "Waiting for the workload certificates enablement. This may take up to 20 minutes ..."
+  # Enabling workload certificate feature on a cluster will result in
+  # the cluster restarting and the cluster becoming unreachable for minutes.
+  # The cluster restart may happen at a random time after the enablement.
+  # Therefore, wait 15 minutes before checking the connection to k8s is recovered.
+  sleep 900
+  # Check the connection to k8s is recovered.
+  local REACHABLE; REACHABLE=false
+  for i in {1..3}; do
+    local OUT; OUT=$(kubectl version -o json 2>/dev/null | jq .serverVersion.major -r 2>/dev/null)
+    if [[ $OUT -eq 1 ]]; then
+      info "The k8s cluster is reachable."
+      REACHABLE=true
+      break
+    else
+      info "The k8s cluster not reachable, try again ..."
+      sleep 60
+    fi
+  done
+  if ! $REACHABLE; then
+    fatal "The k8s cluster is not reachable, exit."
+  fi
+
+  # Check the status of workload certificate feature
+  local ENABLED; ENABLED=false
+  for i in {1..2}; do
+    local OUT; OUT="$(curl -H "X-Goog-User-Project: ${FLEET_ID}" \
+      -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+      "https://${GKEHUB_API}/v1alpha/projects/${FLEET_ID}/locations/global/features/workloadcertificate" 2>/dev/null | \
+      grep -i -c "certificateManagement.*ENABLED")"
+    if [[ $OUT -gt 0 ]]; then
+      info "Workload certificate management is enabled."
+      ENABLED=true
+      break
+    else
+      info "Workload certificate management is not enabled, try again ..."
+      sleep 60
+    fi
+  done
+  if ! $ENABLED; then
+    warn "The workload certificate management is not enabled. The workload certificates may not work until the management is enabled."
+  fi
 }
 
 x_install_managed_cas_for_mcp() {

--- a/asmcli/commands/validate.sh
+++ b/asmcli/commands/validate.sh
@@ -55,8 +55,7 @@ validate_dependencies() {
         enable_service_mesh_feature
       fi
       if [[ "${CA}" == "managed_cas" ]]; then
-        info "Wait 3 minutes for GKE HUB API enablement to propagate to the systems ..."
-        sleep 180
+        x_wait_for_gke_hub_api_enablement
         x_enable_workload_certificate_on_fleet "gkehub.googleapis.com"
       fi
     else

--- a/asmcli/commands/validate.sh
+++ b/asmcli/commands/validate.sh
@@ -55,6 +55,8 @@ validate_dependencies() {
         enable_service_mesh_feature
       fi
       if [[ "${CA}" == "managed_cas" ]]; then
+        info "Wait 3 minutes for GKE HUB API enablement to propagate to the systems ..."
+        sleep 180
         x_enable_workload_certificate_on_fleet "gkehub.googleapis.com"
       fi
     else
@@ -73,6 +75,7 @@ validate_dependencies() {
     local HUB_MEMBERSHIP_ID; HUB_MEMBERSHIP_ID="$(context_get-option "HUB_MEMBERSHIP_ID")"
     if [[ "${CA}" == "managed_cas" ]]; then
       x_enable_workload_certificate_on_membership "gkehub.googleapis.com" "${FLEET_ID}" "${HUB_MEMBERSHIP_ID}"
+      x_wait_for_enabling_workload_certificates "gkehub.googleapis.com" "${FLEET_ID}"
     fi
   elif should_validate && [[ "${USE_HUB_WIP}" -eq 1 || "${USE_VM}" -eq 1 ]]; then
     exit_if_cluster_unregistered

--- a/asmcli/components/ca/managed-cas.sh
+++ b/asmcli/components/ca/managed-cas.sh
@@ -75,6 +75,54 @@ x_enable_workload_certificate_on_membership() {
      -d "${ENABLEFEATURE}" "https://${GKEHUB_API}/v1alpha/projects/${FLEET_ID}/locations/global/features/workloadcertificate?update_mask=membership_specs"
 }
 
+x_wait_for_enabling_workload_certificates() {
+  local GKEHUB_API; GKEHUB_API="$1"
+  local FLEET_ID; FLEET_ID="$2"
+
+  info "Waiting for the workload certificates enablement. This may take up to 20 minutes ..."
+  # Enabling workload certificate feature on a cluster will result in
+  # the cluster restarting and the cluster becoming unreachable for minutes.
+  # The cluster restart may happen at a random time after the enablement.
+  # Therefore, wait 15 minutes before checking the connection to k8s is recovered.
+  sleep 900
+  # Check the connection to k8s is recovered.
+  local REACHABLE; REACHABLE=false
+  for i in {1..3}; do
+    local OUT; OUT=$(kubectl version -o json 2>/dev/null | jq .serverVersion.major -r 2>/dev/null)
+    if [[ $OUT -eq 1 ]]; then
+      info "The k8s cluster is reachable."
+      REACHABLE=true
+      break
+    else
+      info "The k8s cluster not reachable, try again ..."
+      sleep 60
+    fi
+  done
+  if ! $REACHABLE; then
+    fatal "The k8s cluster is not reachable, exit."
+  fi
+
+  # Check the status of workload certificate feature
+  local ENABLED; ENABLED=false
+  for i in {1..2}; do
+    local OUT; OUT="$(curl -H "X-Goog-User-Project: ${FLEET_ID}" \
+      -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+      "https://${GKEHUB_API}/v1alpha/projects/${FLEET_ID}/locations/global/features/workloadcertificate" 2>/dev/null | \
+      grep -i -c "certificateManagement.*ENABLED")"
+    if [[ $OUT -gt 0 ]]; then
+      info "Workload certificate management is enabled."
+      ENABLED=true
+      break
+    else
+      info "Workload certificate management is not enabled, try again ..."
+      sleep 60
+    fi
+  done
+  if ! $ENABLED; then
+    warn "The workload certificate management is not enabled. The workload certificates may not work until the management is enabled."
+  fi
+}
+
 x_install_managed_cas_for_mcp() {
   info "Configuring managed CAS for managed control plane..."
 

--- a/asmcli/components/ca/managed-cas.sh
+++ b/asmcli/components/ca/managed-cas.sh
@@ -113,18 +113,18 @@ x_wait_for_enabling_workload_certificates() {
   # Check the connection to k8s is recovered.
   local REACHABLE; REACHABLE=0
   for i in {1..3}; do
-    local OUT; OUT=$(kubectl version -o json 2>/dev/null | jq .serverVersion.major -r 2>/dev/null)
-    if [[ $OUT -eq 1 ]]; then
-      info "The k8s cluster is reachable."
+    local OUT; OUT=$(kubectl get ds -n kube-system gke-spiffe-node-agent 2>/dev/null | grep -i "gke-spiffe-node-agent")
+    if [[ -z "$OUT" ]]; then
+      info "The k8s cluster is reachable and gke-spiffe-node-agent is found."
       REACHABLE=1
       break
     else
-      info "The k8s cluster not reachable, try again ..."
+      info "The k8s cluster is not reachable or gke-spiffe-node-agent is not found, try again ..."
       sleep 60
     fi
   done
   if [[ "${REACHABLE}" -eq 0 ]]; then
-    fatal "The k8s cluster is not reachable, exit."
+    fatal "The k8s cluster is not reachable or gke-spiffe-node-agent is not found, exit."
   fi
 }
 

--- a/asmcli/components/ca/managed-cas.sh
+++ b/asmcli/components/ca/managed-cas.sh
@@ -75,51 +75,56 @@ x_enable_workload_certificate_on_membership() {
      -d "${ENABLEFEATURE}" "https://${GKEHUB_API}/v1alpha/projects/${FLEET_ID}/locations/global/features/workloadcertificate?update_mask=membership_specs"
 }
 
+x_wait_for_gke_hub_api_enablement() {
+  info "Wait 3 minutes for GKE HUB API enablement to propagate to the systems ..."
+  sleep 180
+}
+
 x_wait_for_enabling_workload_certificates() {
   local GKEHUB_API; GKEHUB_API="$1"
   local FLEET_ID; FLEET_ID="$2"
 
   info "Waiting for the workload certificates enablement. This may take up to 20 minutes ..."
-  # Enabling workload certificate feature on a cluster will result in
-  # the cluster restarting and the cluster becoming unreachable for minutes.
-  # The cluster restart may happen at a random time after the enablement.
-  # Therefore, wait 15 minutes before checking the connection to k8s is recovered.
-  sleep 900
-  # Check the connection to k8s is recovered.
-  local REACHABLE; REACHABLE=false
-  for i in {1..3}; do
-    local OUT; OUT=$(kubectl version -o json 2>/dev/null | jq .serverVersion.major -r 2>/dev/null)
-    if [[ $OUT -eq 1 ]]; then
-      info "The k8s cluster is reachable."
-      REACHABLE=true
-      break
-    else
-      info "The k8s cluster not reachable, try again ..."
-      sleep 60
-    fi
-  done
-  if ! $REACHABLE; then
-    fatal "The k8s cluster is not reachable, exit."
-  fi
-
   # Check the status of workload certificate feature
-  local ENABLED; ENABLED=false
+  local ENABLED; ENABLED=0
   for i in {1..2}; do
     local OUT; OUT="$(curl -H "X-Goog-User-Project: ${FLEET_ID}" \
       -H "Authorization: Bearer $(gcloud auth print-access-token)" \
       "https://${GKEHUB_API}/v1alpha/projects/${FLEET_ID}/locations/global/features/workloadcertificate" 2>/dev/null | \
-      grep -i -c "certificateManagement.*ENABLED")"
-    if [[ $OUT -gt 0 ]]; then
+      grep -i "certificateManagement.*ENABLED")"
+    if [[ -z "$OUT" ]]; then
       info "Workload certificate management is enabled."
-      ENABLED=true
+      ENABLED=1
       break
     else
       info "Workload certificate management is not enabled, try again ..."
       sleep 60
     fi
   done
-  if ! $ENABLED; then
+  if [[ "${ENABLED}" -eq 0 ]]; then
     warn "The workload certificate management is not enabled. The workload certificates may not work until the management is enabled."
+  fi
+
+  # Enabling workload certificate feature on a cluster will result in
+  # the cluster restarting and the cluster becoming unreachable for minutes.
+  # The cluster restart may happen at a random time after the enablement.
+  # Therefore, wait 15 minutes before checking the connection to k8s is recovered.
+  sleep 900
+  # Check the connection to k8s is recovered.
+  local REACHABLE; REACHABLE=0
+  for i in {1..3}; do
+    local OUT; OUT=$(kubectl version -o json 2>/dev/null | jq .serverVersion.major -r 2>/dev/null)
+    if [[ $OUT -eq 1 ]]; then
+      info "The k8s cluster is reachable."
+      REACHABLE=1
+      break
+    else
+      info "The k8s cluster not reachable, try again ..."
+      sleep 60
+    fi
+  done
+  if [[ "${REACHABLE}" -eq 0 ]]; then
+    fatal "The k8s cluster is not reachable, exit."
   fi
 }
 


### PR DESCRIPTION
Enabling workload certificate feature on a cluster will result in the cluster restarting and the cluster becoming unreachable for minutes. The PR waits for the k8s cluster becoming reachable and checks the workload certificate enablement status before proceeding with the installation.