### PR TITLE
fix: asmcli doesnt work without readlink binary on bsd-style OS

### DIFF
--- a/asmcli/README.md
+++ b/asmcli/README.md
@@ -60,9 +60,11 @@ This script requires access to the following tools:
 - kubectl
 - sed
 - tr
+- readlink
 
-Google Cloud Shell pre-installs these tools except `kpt`, which
-you can install by using `sudo apt-get install google-cloud-sdk-kpt`.
+Google Cloud Shell pre-installs these tools except `kpt` and `readlink` (only for BSD-style OS).
+Install `readlink` on macos by using `brew install coreutils`.
+`kpt` is installed automatically when using `asmcli` script (with a fixed version).
 
 In addition, you need a GKE Kubernetes cluster with at least 8 vCPUs that use
 machine types with at least 4 vCPUs. If you are not the Project Owner for

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -4619,12 +4619,7 @@ EOF
 }
 
 init() {
-  # BSD-style readlink apparently doesn't have the same -f toggle on readlink
-  case "$(uname)" in
-    Linux ) APATH="readlink";;
-    Darwin) APATH="stat";;
-    *);;
-  esac
+  APATH="readlink"
   readonly APATH
 
   local REVISION_LABEL
@@ -5181,6 +5176,7 @@ sed
 tr
 head
 csplit
+readlink
 EOF
 
   while read -r FLAG; do


### PR DESCRIPTION
Using `./asmcli` on a macos system returns an error since kpt isn't properly configured. 
As the commented line in the script says, the `stat` doesn't have the same behavior as `readlink`. It's required to use `readlink` to set the right path for kpt.

Using readlink (after installing using `brew install coreutils`) the script works as expected.
The option to install `kpt` manually doesn't work either. The version is fixed on `asmcli` to `0.39.3` and there are breaking changes in the CLI when we use the latest version.