### PR TITLE
Remove incorrect warning message

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -3400,40 +3400,6 @@ required_iam_roles_registration() {
   echo roles/gkehub.admin
 }
 
-old_required_apis() {
-  local CA; CA="$(context_get-option "CA")"
-    cat << EOF
-container.googleapis.com
-monitoring.googleapis.com
-logging.googleapis.com
-cloudtrace.googleapis.com
-meshconfig.googleapis.com
-iamcredentials.googleapis.com
-gkeconnect.googleapis.com
-gkehub.googleapis.com
-cloudresourcemanager.googleapis.com
-stackdriver.googleapis.com
-EOF
-   case "${CA}" in
-   mesh_ca)
-     echo meshca.googleapis.com
-     ;;
-   gcp_cas)
-     echo privateca.googleapis.com
-     ;;
-   managed_cas)
-     echo workloadcertificate.googleapis.com
-     ;;
-    *);;
-  esac
-}
-
-old_managed_required_apis() {
-    cat << EOF
-connectgateway.googleapis.com
-EOF
-}
-
 # [START required_apis]
 required_apis() {
   local CA; CA="$(context_get-option "CA")"
@@ -5414,23 +5380,10 @@ EOF
 exit_if_apis_not_enabled() {
   local ENABLED; ENABLED="$(get_enabled_apis)";
   local REQUIRED; REQUIRED="$(required_apis)";
-  local OLD_REQUIRED; OLD_REQUIRED="$(old_required_apis)";
-  if is_managed; then
-    OLD_REQUIRED="${OLD_REQUIRED} $(old_managed_required_apis)"
-  fi
   local NOTFOUND; NOTFOUND="";
-  local OLD_NOTFOUND; OLD_NOTFOUND="";
 
   info "Checking required APIs..."
   NOTFOUND="$(find_missing_strings "${REQUIRED}" "${ENABLED}")"
-  OLD_NOTFOUND="$(find_missing_strings "${OLD_REQUIRED}" "${ENABLED}")"
-
-  if [[ -z "${OLD_NOTFOUND}" ]]; then
-    if [[ -n "${NOTFOUND}" ]]; then
-      warn "mesh.googleapis.com will be required in future versions of ASM."
-    fi
-    return;
-  fi
 
   if [[ -n "${NOTFOUND}" ]]; then
     for api in $(echo "${NOTFOUND}" | tr ' ' '\n'); do

--- a/asmcli/lib/installation_dependencies.sh
+++ b/asmcli/lib/installation_dependencies.sh
@@ -56,40 +56,6 @@ required_iam_roles_registration() {
   echo roles/gkehub.admin
 }
 
-old_required_apis() {
-  local CA; CA="$(context_get-option "CA")"
-    cat << EOF
-container.googleapis.com
-monitoring.googleapis.com
-logging.googleapis.com
-cloudtrace.googleapis.com
-meshconfig.googleapis.com
-iamcredentials.googleapis.com
-gkeconnect.googleapis.com
-gkehub.googleapis.com
-cloudresourcemanager.googleapis.com
-stackdriver.googleapis.com
-EOF
-   case "${CA}" in
-   mesh_ca)
-     echo meshca.googleapis.com
-     ;;
-   gcp_cas)
-     echo privateca.googleapis.com
-     ;;
-   managed_cas)
-     echo workloadcertificate.googleapis.com
-     ;;
-    *);;
-  esac
-}
-
-old_managed_required_apis() {
-    cat << EOF
-connectgateway.googleapis.com
-EOF
-}
-
 # [START required_apis]
 required_apis() {
   local CA; CA="$(context_get-option "CA")"

--- a/asmcli/lib/validate.sh
+++ b/asmcli/lib/validate.sh
@@ -308,23 +308,10 @@ EOF
 exit_if_apis_not_enabled() {
   local ENABLED; ENABLED="$(get_enabled_apis)";
   local REQUIRED; REQUIRED="$(required_apis)";
-  local OLD_REQUIRED; OLD_REQUIRED="$(old_required_apis)";
-  if is_managed; then
-    OLD_REQUIRED="${OLD_REQUIRED} $(old_managed_required_apis)"
-  fi
   local NOTFOUND; NOTFOUND="";
-  local OLD_NOTFOUND; OLD_NOTFOUND="";
 
   info "Checking required APIs..."
   NOTFOUND="$(find_missing_strings "${REQUIRED}" "${ENABLED}")"
-  OLD_NOTFOUND="$(find_missing_strings "${OLD_REQUIRED}" "${ENABLED}")"
-
-  if [[ -z "${OLD_NOTFOUND}" ]]; then
-    if [[ -n "${NOTFOUND}" ]]; then
-      warn "mesh.googleapis.com will be required in future versions of ASM."
-    fi
-    return;
-  fi
 
   if [[ -n "${NOTFOUND}" ]]; then
     for api in $(echo "${NOTFOUND}" | tr ' ' '\n'); do

--- a/asmcli/tests/unit_test_common.bash
+++ b/asmcli/tests/unit_test_common.bash
@@ -172,20 +172,7 @@ EOF
 
   if [[ "${*}" == *"services list --enabled"*"this_should_pass" ]]; then
     cat <<EOF
-container.googleapis.com
-monitoring.googleapis.com
-logging.googleapis.com
-cloudtrace.googleapis.com
-meshconfig.googleapis.com
-iamcredentials.googleapis.com
-gkeconnect.googleapis.com
-gkehub.googleapis.com
-cloudresourcemanager.googleapis.com
-stackdriver.googleapis.com
-meshconfig.googleapis.com
-meshca.googleapis.com
-opsconfigmonitoring.googleapis.com
-privateca.googleapis.com
+mesh.googleapis.com
 EOF
   return 0
   fi


### PR DESCRIPTION
We made this required in February, but there's one code path that still might erroneously print this message.