### PR TITLE
fix the bug when the cluster info is not populated

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -2942,6 +2942,9 @@ istio_namespace_exists() {
 
 is_autopilot() {
   if [[ "${IS_AUTOPILOT}" -eq 1 ]]; then return; fi
+  local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
+  local CLUSTER_NAME; CLUSTER_NAME="$(context_get-option "CLUSTER_NAME")"
+  local CLUSTER_LOCATION; CLUSTER_LOCATION="$(context_get-option "CLUSTER_LOCATION")"
 
   local AUTOPILOT_MODE; AUTOPILOT_MODE="$(gcloud container clusters describe "${CLUSTER_NAME}" \
     --region "${CLUSTER_LOCATION}" \

--- a/asmcli/lib/checks.sh
+++ b/asmcli/lib/checks.sh
@@ -465,6 +465,9 @@ istio_namespace_exists() {
 
 is_autopilot() {
   if [[ "${IS_AUTOPILOT}" -eq 1 ]]; then return; fi
+  local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
+  local CLUSTER_NAME; CLUSTER_NAME="$(context_get-option "CLUSTER_NAME")"
+  local CLUSTER_LOCATION; CLUSTER_LOCATION="$(context_get-option "CLUSTER_LOCATION")"
 
   local AUTOPILOT_MODE; AUTOPILOT_MODE="$(gcloud container clusters describe "${CLUSTER_NAME}" \
     --region "${CLUSTER_LOCATION}" \


### PR DESCRIPTION
GKE Autopilot enforcing managed CNI:
```
2022-12-20T22:36:49.881961 asmcli: Running: '/usr/bin/gcloud container clusters describe autopilot-cluster-1 --region us-central1 --project zhengzhe-test-project --format json'
2022-12-20T22:36:49.931482 asmcli: -------------
2022-12-20T22:36:51.099157 asmcli: [WARNING]: Managed CNI is required to continue installing managed ASM on GKE Autopilot.
2022-12-20T22:36:51.175913 asmcli: [WARNING]: Confirm or pass --use-managed-cni flag to asmcli.
Continue? [y/N] y
```


GKE Standard installing local CP:
```
2022-12-20T22:40:32.059301 asmcli: -------------
components.pilot.k8s.replicaCount should not be set when values.pilot.autoscaleEnabled is true
✔ Istio core installed                                                                  
✔ Istiod installed                                                                      
✔ Installation complete 
```
GEK Standard installing managed CP:
```
2022-12-20T22:44:21.352008 asmcli: Running: '/usr/bin/kubectl --kubeconfig /tmp/tmp.nr5SGfP8yZ/asm_kubeconfig --context gke_zhengzhe-test-project_us-central1_cluster-1-24 wait --for=condition=ProvisioningFinished controlplanerevision asm-managed -n istio-system --timeout 600s'
```