### PR TITLE
Preview support for arm64 Darwin

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -4457,7 +4457,10 @@ download_asm() {
 
   case "$(uname)" in
     Linux ) OS="linux-amd64";;
-    Darwin) OS="osx";;
+    Darwin)
+      OS="osx"
+      if [[ "$(uname -a)" = "arm64" ]]; then OS="${OS}-arm64"; fi
+    ;;
     *     ) fatal "$(uname) is not a supported OS.";;
   esac
 
@@ -5190,7 +5193,7 @@ EOF
   trap "$(shopt -p nocasematch)" RETURN
   shopt -s nocasematch
   if [[ "$(uname -m)" != "x86_64" ]]; then
-    fatal "Installation is only supported on x86_64."
+    warn "Installation is only supported on x86_64."
   fi
 }
 

--- a/asmcli/lib/util.sh
+++ b/asmcli/lib/util.sh
@@ -206,7 +206,10 @@ download_asm() {
 
   case "$(uname)" in
     Linux ) OS="linux-amd64";;
-    Darwin) OS="osx";;
+    Darwin)
+      OS="osx"
+      if [[ "$(uname -a)" = "arm64" ]]; then OS="${OS}-arm64"; fi
+    ;;
     *     ) fatal "$(uname) is not a supported OS.";;
   esac
 

--- a/asmcli/lib/validate.sh
+++ b/asmcli/lib/validate.sh
@@ -88,7 +88,7 @@ EOF
   trap "$(shopt -p nocasematch)" RETURN
   shopt -s nocasematch
   if [[ "$(uname -m)" != "x86_64" ]]; then
-    fatal "Installation is only supported on x86_64."
+    warn "Installation is only supported on x86_64."
   fi
 }
 


### PR DESCRIPTION
We're still not officially supporting non-Linux platforms, but now that the istioctl binary is compiled and released we can at least allow access to it.