### PR TITLE
Bump kube-rbac-proxy version

### DIFF
--- a/asm/canonical-service/controller.yaml
+++ b/asm/canonical-service/controller.yaml
@@ -310,7 +310,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         name: kube-rbac-proxy
         resources:
           limits:


### PR DESCRIPTION
A customer has reported that v0.5 has security vulnerabilities, and newer versions have been available for quite a while.  Tested and confirmed that the controller works with the new version.