### PR TITLE
Remove fetching spiffe bundles from endpoints for default template

### DIFF
--- a/asm/istio/istio-operator.yaml
+++ b/asm/istio/istio-operator.yaml
@@ -67,8 +67,6 @@ spec:
             value: "" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.idp-url"}
           - name: GCP_METADATA
             value: "PROJECT_ID|PROJECT_NUMBER|asm-cluster|us-central1-c" # {"$ref":"#/definitions/io.k8s.cli.substitutions.gke-metadata"}
-          - name: SPIFFE_BUNDLE_ENDPOINTS
-            value: "" # {"$ref":"#/definitions/io.k8s.cli.substitutions.spiffe-bundle-endpoints"}
           - name: ENABLE_STACKDRIVER_MONITORING
             value: "true" # {"$ref":"#/definitions/io.k8s.cli.setters.anthos.servicemesh.controlplane.monitoring.enabled"}
           - name: TOKEN_AUDIENCES

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -2601,9 +2601,7 @@ configure_package() {
 
   kpt cfg set asm anthos.servicemesh.trustDomain "${FLEET_ID}.svc.id.goog"
   kpt cfg set asm anthos.servicemesh.tokenAudiences "istio-ca,${FLEET_ID}.svc.id.goog"
-  if [[ "${CA}" == "mesh_ca" ]]; then
-    kpt cfg set asm anthos.servicemesh.spiffeBundleEndpoints "${FLEET_ID}.svc.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json"
-  fi
+
   if [[ "${USE_VPCSC}" -eq 1 ]]; then
     kpt cfg set asm anthos.servicemesh.managed-controlplane.vpcsc.enabled "true"
   fi

--- a/asmcli/lib/config.sh
+++ b/asmcli/lib/config.sh
@@ -55,9 +55,7 @@ configure_package() {
 
   kpt cfg set asm anthos.servicemesh.trustDomain "${FLEET_ID}.svc.id.goog"
   kpt cfg set asm anthos.servicemesh.tokenAudiences "istio-ca,${FLEET_ID}.svc.id.goog"
-  if [[ "${CA}" == "mesh_ca" ]]; then
-    kpt cfg set asm anthos.servicemesh.spiffeBundleEndpoints "${FLEET_ID}.svc.id.goog|https://storage.googleapis.com/mesh-ca-resources/spiffe_bundle.json"
-  fi
+
   if [[ "${USE_VPCSC}" -eq 1 ]]; then
     kpt cfg set asm anthos.servicemesh.managed-controlplane.vpcsc.enabled "true"
   fi


### PR DESCRIPTION
For Control plane Authentication, Istiod can authenticate the sidecar/gateways using JWT. Requiring Istiod to authenticate the dataplane using the mTLS cert signed by the CA is unnecessary.

