### PR TITLE
Do not support channel selection via CLI args

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -3640,8 +3640,8 @@ parse_args() {
         shift 2
         ;;
       --channel)
-        arg_required "${@}"
-        context_set-option "CHANNEL" "${2}"
+        warn "Specifying --channel is not supported as of 1.17, channels are assigned automatically."
+        warn "See verbose help output or Google Cloud docs for details on how channels are chosen."
         shift 2
         ;;
       --offline)

--- a/asmcli/lib/parse.sh
+++ b/asmcli/lib/parse.sh
@@ -218,8 +218,8 @@ parse_args() {
         shift 2
         ;;
       --channel)
-        arg_required "${@}"
-        context_set-option "CHANNEL" "${2}"
+        warn "Specifying --channel is not supported as of 1.17, channels are assigned automatically."
+        warn "See verbose help output or Google Cloud docs for details on how channels are chosen."
         shift 2
         ;;
       --offline)


### PR DESCRIPTION
Allowing this gives the wrong impression that GKE and ASM channels are independent, which is useless at best and dangerous at worst. We shouldn't be making it easier for customers to run nonstandard environments.