### PR TITLE
Merge staging-1.18 to release-1.18

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -76,7 +76,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.tag
-          value: 1.18.2-asm.0
+          value: 1.18.2-asm.4
           isSet: true
     io.k8s.cli.setters.anthos.servicemesh.managed-controlplane.vpcsc.enabled:
       type: string

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -41,7 +41,7 @@ _CI_I_AM_A_TEST_ROBOT="${_CI_I_AM_A_TEST_ROBOT:=0}"; readonly _CI_I_AM_A_TEST_RO
 MAJOR="${MAJOR:=1}"; readonly MAJOR;
 MINOR="${MINOR:=18}"; readonly MINOR;
 POINT="${POINT:=2}"; readonly POINT;
-REV="${REV:=0}"; readonly REV;
+REV="${REV:=4}"; readonly REV;
 CONFIG_VER="${CONFIG_VER:="1"}"; readonly CONFIG_VER;
 K8S_MINOR=0
 
@@ -427,7 +427,7 @@ install_one_remote_secret() {
 
   info "Installing remote secret ${SECRET_NAME} on ${KCF2}..."
 
-  retry 2 istioctl x create-remote-secret \
+  retry 2 istioctl create-remote-secret \
     --kubeconfig="${KCF1}" \
     --context="${CTX1}" \
     --name="${SECRET_NAME}" | \
@@ -859,21 +859,6 @@ OPTIONS:
                                       cluster. Defaults to "gcp" (for GKE clusters).
                                       For all other platforms use "multicloud".
                                       Allowed values for <PLATFORM> are {gcp|multicloud}.
-  --channel              <CHANNEL>    The release channel for the control plane revision.
-                                      If the user specifies the channel to be used, only
-                                      the Control Plane Revision associated with this
-                                      channel will be provisioned. Otherwise, the mapping
-                                      between Multicloud/GKE channel and the ASM Channel is
-                                      as following:
-                                      For Multicloud:
-                                        ASM provisions Regular channel.
-                                      For GKE:
-                                        GKE Channel  |  ASM Channel
-                                        -------------|----------------
-                                        Rapid        |  Rapid
-                                        Regular      |  Regular
-                                        Stable       |  Stable
-                                        Static       |  Regular
 
   The following four options must be passed together and are only necessary
   for using a custom certificate for Citadel. Users that aren't sure whether
@@ -918,6 +903,15 @@ FLAGS:
      --use_managed_cni                Deprecated. Managed CNI now defaults to be on.
      --managed                        Provision a remote, managed control plane
                                       instead of installing one in-cluster.
+                                      The channel matches with the GKE version:
+                                        GKE Channel  |  ASM Channel
+                                        -------------|----------------
+                                        Rapid        |  Rapid
+                                        Regular      |  Regular
+                                        Stable       |  Stable
+                                        Static       |  Regular
+                                      Any non-GKE cluster gets the Regular
+                                      channel.
      --use_vpcsc                      Provision a remote, managed control plane in
                                       VPCSC environment.
      --offline                        Perform an offline installation using the pre-downloaded
@@ -1071,8 +1065,9 @@ FLAGS:
   --version                           Print the version of this tool and exit.
 
 EXAMPLE:
-The following invocation will create a mesh using the provided 6 clusters
-by registering them to a fleet named "my_cluster" and install remote secrets on each pair of clusters:
+The following invocation will create a mesh using the provided 3 clusters
+by registering them to a fleet named "my-fleet" and install remote secrets (if
+necessary) on each pair of clusters:
 
   $> ${SCRIPT_NAME} \\
       create-mesh \\
@@ -2594,8 +2589,14 @@ configure_package() {
     kpt cfg set asm gcloud.core.project "${PROJECT_ID}"
     kpt cfg set asm gcloud.compute.location "${CLUSTER_LOCATION}"
   else
-    configure_off_gcp_gcp_metadata "${FLEET_ID}" "${HUB_MEMBERSHIP_ID}" "${PROJECT_ID}"
-
+    kpt cfg set asm gcloud.core.project "${FLEET_ID}"
+    if [[ -n "${HUB_MEMBERSHIP_ID}" ]]; then
+      kpt cfg set asm gcloud.container.cluster "${HUB_MEMBERSHIP_ID}"
+    else
+      kpt cfg set asm gcloud.container.cluster "cluster" # default off-GCP cluster name
+    fi
+    # "global" is the current default value for off-GCP
+    kpt cfg set asm gcloud.compute.location "global"
     if [[ "${CA}" == "citadel" && "${INCLUDES_STACKDRIVER}" -eq 0 ]]; then
       kpt cfg set asm anthos.servicemesh.controlplane.monitoring.enabled "false"
     fi
@@ -2627,34 +2628,6 @@ configure_package() {
 
   configure_ca
   configure_control_plane
-}
-
-configure_off_gcp_gcp_metadata(){
-  local FLEET_ID; FLEET_ID="${1}"
-  local HUB_MEMBERSHIP_ID; HUB_MEMBERSHIP_ID="${2}"
-  local PROJECT_ID; PROJECT_ID="${3}"
-  
-  local OFF_GCP_MEMBERSHIP_NAME;
-  local OFF_GCP_CLUSTER_LOCATION;
-
-  kpt cfg set asm gcloud.core.project "${FLEET_ID}"
-
-  OFF_GCP_MEMBERSHIP_NAME="cluster" # default off-GCP cluster name
-  if [[ -n "${HUB_MEMBERSHIP_ID}" ]]; then
-    OFF_GCP_MEMBERSHIP_NAME="${HUB_MEMBERSHIP_ID}" # off-GCP cluster name is used for membership name
-  fi
-  kpt cfg set asm gcloud.container.cluster "${OFF_GCP_MEMBERSHIP_NAME}"
-
-  if [[ "${OFF_GCP_MEMBERSHIP_NAME}" == "cluster" ]]; then
-    kpt cfg set asm gcloud.compute.location "global"
-  else
-    OFF_GCP_CLUSTER_LOCATION=$(get_monitoring_config_membership_location "${OFF_GCP_MEMBERSHIP_NAME}" "${PROJECT_ID}")
-    if [[ -z "${OFF_GCP_CLUSTER_LOCATION}" ]]; then
-      # "global" is the current default value for off-GCP
-      OFF_GCP_CLUSTER_LOCATION="global"
-    fi
-    kpt cfg set asm gcloud.compute.location "${OFF_GCP_CLUSTER_LOCATION}"
-  fi
 }
 
 configure_kubectl(){
@@ -3366,7 +3339,7 @@ populate_fleet_info() {
     -n "${HUB_IDP_URL}" ]]; then return; fi
 
   if ! is_membership_crd_installed; then return; fi
-HUB_MEMBERSHIP_ID="$(kubectl get memberships.hub.gke.io membership -o=json | jq .spec.owner.id | sed 's/^\"\/\/\(autopush-\)\{0,1\}gkehub\(.sandbox\)\{0,1\}.googleapis.com\/projects\/\(.*\)\/locations\/global\/memberships\/\(.*\)\"$/\4/g')"
+  HUB_MEMBERSHIP_ID="$(kubectl get memberships.hub.gke.io membership -o=json | jq .spec.owner.id | sed 's/^\"\/\/\(autopush-\)\{0,1\}gkehub\(.sandbox\)\{0,1\}.googleapis.com\/projects\/\(.*\)\/locations\/\(.*\)\/memberships\/\(.*\)\"$/\5/g')"
   context_set-option "HUB_MEMBERSHIP_ID" "${HUB_MEMBERSHIP_ID}"
   HUB_IDP_URL="$(kubectl get memberships.hub.gke.io membership -o=jsonpath='{.spec.identity_provider}')"
   context_set-option "HUB_IDP_URL" "${HUB_IDP_URL}"
@@ -4696,15 +4669,6 @@ ensure_cross_project_sa() {
     return
   fi
   false
-}
-
-get_monitoring_config_membership_location () {
-  local MEMBERSHIP_NAME; MEMBERSHIP_NAME="${1}"
-  local PROJECT_ID; PROJECT_ID="${2}"
-
-  LOCATION="$(gcloud container hub memberships describe "${MEMBERSHIP_NAME}" --project "${PROJECT_ID}" --format="value(monitoringConfig.location)")"
-  
-  echo "${LOCATION}"
 }
 
 validate_revision_label() {

--- a/asmcli/asmcli.sh
+++ b/asmcli/asmcli.sh
@@ -37,7 +37,7 @@ _CI_I_AM_A_TEST_ROBOT="${_CI_I_AM_A_TEST_ROBOT:=0}"; readonly _CI_I_AM_A_TEST_RO
 MAJOR="${MAJOR:=1}"; readonly MAJOR;
 MINOR="${MINOR:=18}"; readonly MINOR;
 POINT="${POINT:=2}"; readonly POINT;
-REV="${REV:=0}"; readonly REV;
+REV="${REV:=4}"; readonly REV;
 CONFIG_VER="${CONFIG_VER:="1"}"; readonly CONFIG_VER;
 K8S_MINOR=0
 

--- a/asmcli/commands/create-mesh.sh
+++ b/asmcli/commands/create-mesh.sh
@@ -204,7 +204,7 @@ install_one_remote_secret() {
 
   info "Installing remote secret ${SECRET_NAME} on ${KCF2}..."
 
-  retry 2 istioctl x create-remote-secret \
+  retry 2 istioctl create-remote-secret \
     --kubeconfig="${KCF1}" \
     --context="${CTX1}" \
     --name="${SECRET_NAME}" | \

--- a/asmcli/commands/help.sh
+++ b/asmcli/commands/help.sh
@@ -124,21 +124,6 @@ OPTIONS:
                                       cluster. Defaults to "gcp" (for GKE clusters).
                                       For all other platforms use "multicloud".
                                       Allowed values for <PLATFORM> are {gcp|multicloud}.
-  --channel              <CHANNEL>    The release channel for the control plane revision.
-                                      If the user specifies the channel to be used, only
-                                      the Control Plane Revision associated with this
-                                      channel will be provisioned. Otherwise, the mapping
-                                      between Multicloud/GKE channel and the ASM Channel is
-                                      as following:
-                                      For Multicloud:
-                                        ASM provisions Regular channel.
-                                      For GKE:
-                                        GKE Channel  |  ASM Channel
-                                        -------------|----------------
-                                        Rapid        |  Rapid
-                                        Regular      |  Regular
-                                        Stable       |  Stable
-                                        Static       |  Regular
 
   The following four options must be passed together and are only necessary
   for using a custom certificate for Citadel. Users that aren't sure whether
@@ -183,6 +168,15 @@ FLAGS:
      --use_managed_cni                Deprecated. Managed CNI now defaults to be on.
      --managed                        Provision a remote, managed control plane
                                       instead of installing one in-cluster.
+                                      The channel matches with the GKE version:
+                                        GKE Channel  |  ASM Channel
+                                        -------------|----------------
+                                        Rapid        |  Rapid
+                                        Regular      |  Regular
+                                        Stable       |  Stable
+                                        Static       |  Regular
+                                      Any non-GKE cluster gets the Regular
+                                      channel.
      --use_vpcsc                      Provision a remote, managed control plane in
                                       VPCSC environment.
      --offline                        Perform an offline installation using the pre-downloaded
@@ -336,8 +330,9 @@ FLAGS:
   --version                           Print the version of this tool and exit.
 
 EXAMPLE:
-The following invocation will create a mesh using the provided 6 clusters
-by registering them to a fleet named "my_cluster" and install remote secrets on each pair of clusters:
+The following invocation will create a mesh using the provided 3 clusters
+by registering them to a fleet named "my-fleet" and install remote secrets (if
+necessary) on each pair of clusters:
 
   $> ${SCRIPT_NAME} \\
       create-mesh \\

--- a/asmcli/lib/config.sh
+++ b/asmcli/lib/config.sh
@@ -25,8 +25,14 @@ configure_package() {
     kpt cfg set asm gcloud.core.project "${PROJECT_ID}"
     kpt cfg set asm gcloud.compute.location "${CLUSTER_LOCATION}"
   else
-    configure_off_gcp_gcp_metadata "${FLEET_ID}" "${HUB_MEMBERSHIP_ID}" "${PROJECT_ID}"
-
+    kpt cfg set asm gcloud.core.project "${FLEET_ID}"
+    if [[ -n "${HUB_MEMBERSHIP_ID}" ]]; then
+      kpt cfg set asm gcloud.container.cluster "${HUB_MEMBERSHIP_ID}"
+    else
+      kpt cfg set asm gcloud.container.cluster "cluster" # default off-GCP cluster name
+    fi
+    # "global" is the current default value for off-GCP
+    kpt cfg set asm gcloud.compute.location "global"
     if [[ "${CA}" == "citadel" && "${INCLUDES_STACKDRIVER}" -eq 0 ]]; then
       kpt cfg set asm anthos.servicemesh.controlplane.monitoring.enabled "false"
     fi
@@ -58,34 +64,6 @@ configure_package() {
 
   configure_ca
   configure_control_plane
-}
-
-configure_off_gcp_gcp_metadata(){
-  local FLEET_ID; FLEET_ID="${1}"
-  local HUB_MEMBERSHIP_ID; HUB_MEMBERSHIP_ID="${2}"
-  local PROJECT_ID; PROJECT_ID="${3}"
-  
-  local OFF_GCP_MEMBERSHIP_NAME;
-  local OFF_GCP_CLUSTER_LOCATION;
-
-  kpt cfg set asm gcloud.core.project "${FLEET_ID}"
-
-  OFF_GCP_MEMBERSHIP_NAME="cluster" # default off-GCP cluster name
-  if [[ -n "${HUB_MEMBERSHIP_ID}" ]]; then
-    OFF_GCP_MEMBERSHIP_NAME="${HUB_MEMBERSHIP_ID}" # off-GCP cluster name is used for membership name
-  fi
-  kpt cfg set asm gcloud.container.cluster "${OFF_GCP_MEMBERSHIP_NAME}"
-
-  if [[ "${OFF_GCP_MEMBERSHIP_NAME}" == "cluster" ]]; then
-    kpt cfg set asm gcloud.compute.location "global"
-  else
-    OFF_GCP_CLUSTER_LOCATION=$(get_monitoring_config_membership_location "${OFF_GCP_MEMBERSHIP_NAME}" "${PROJECT_ID}")
-    if [[ -z "${OFF_GCP_CLUSTER_LOCATION}" ]]; then
-      # "global" is the current default value for off-GCP
-      OFF_GCP_CLUSTER_LOCATION="global"
-    fi
-    kpt cfg set asm gcloud.compute.location "${OFF_GCP_CLUSTER_LOCATION}"
-  fi
 }
 
 configure_kubectl(){

--- a/asmcli/lib/installation_dependencies.sh
+++ b/asmcli/lib/installation_dependencies.sh
@@ -421,7 +421,7 @@ populate_fleet_info() {
     -n "${HUB_IDP_URL}" ]]; then return; fi
 
   if ! is_membership_crd_installed; then return; fi
-HUB_MEMBERSHIP_ID="$(kubectl get memberships.hub.gke.io membership -o=json | jq .spec.owner.id | sed 's/^\"\/\/\(autopush-\)\{0,1\}gkehub\(.sandbox\)\{0,1\}.googleapis.com\/projects\/\(.*\)\/locations\/global\/memberships\/\(.*\)\"$/\4/g')"
+  HUB_MEMBERSHIP_ID="$(kubectl get memberships.hub.gke.io membership -o=json | jq .spec.owner.id | sed 's/^\"\/\/\(autopush-\)\{0,1\}gkehub\(.sandbox\)\{0,1\}.googleapis.com\/projects\/\(.*\)\/locations\/\(.*\)\/memberships\/\(.*\)\"$/\5/g')"
   context_set-option "HUB_MEMBERSHIP_ID" "${HUB_MEMBERSHIP_ID}"
   HUB_IDP_URL="$(kubectl get memberships.hub.gke.io membership -o=jsonpath='{.spec.identity_provider}')"
   context_set-option "HUB_IDP_URL" "${HUB_IDP_URL}"

--- a/asmcli/lib/util.sh
+++ b/asmcli/lib/util.sh
@@ -826,12 +826,3 @@ ensure_cross_project_sa() {
   false
 }
 
-get_monitoring_config_membership_location () {
-  local MEMBERSHIP_NAME; MEMBERSHIP_NAME="${1}"
-  local PROJECT_ID; PROJECT_ID="${2}"
-
-  LOCATION="$(gcloud container hub memberships describe "${MEMBERSHIP_NAME}" --project "${PROJECT_ID}" --format="value(monitoringConfig.location)")"
-  
-  echo "${LOCATION}"
-}
-

--- a/scripts/migration/migrate-to-asm
+++ b/scripts/migration/migrate-to-asm
@@ -1435,7 +1435,7 @@ set_default_tag() {
   info "Setting $(asm_revision_label) as the target for \"istio-injection=enabled\"..."
   kubectl patch mutatingwebhookconfigurations istio-sidecar-injector \
     --type=json -p='[{"op": "replace", "path": "/webhooks"}]'
-  run istioctl x revision tag \
+  run istioctl tag \
     set default --revision="$(asm_revision_label)" \
     --overwrite
 }

--- a/scripts/release-asm/common.sh
+++ b/scripts/release-asm/common.sh
@@ -24,10 +24,10 @@ trap 'gsutil retention "${HOLD_TYPE}" release gs://"${STABLE_VERSION_FILE_PATH}"
 
 prod_releases() {
   cat << EOF
-release 1.14
 release 1.15
 release 1.16
 release 1.17
+release 1.18
 EOF
 }
 
@@ -35,10 +35,10 @@ CURRENT_RELEASE="$(prod_releases | tail -n 1)"; readonly CURRENT_RELEASE
 
 staging_releases() {
   cat << EOF
-staging 1.14
 staging 1.15
 staging 1.16
 staging 1.17
+staging 1.18
 EOF
 }
 


### PR DESCRIPTION
* Bump revision 1.18.2-asm.0 (#1481)

* Update release script (#1483)

* Use top level `istioctl` commands for `create-remote-secret` and `tag` (#1484)

Patches for https://github.com/istio/istio/pull/46051 and https://github.com/istio/istio/pull/46257

* Revert Off-GCP metadata population (#1485)

* Add --working-dir alias for output directory

* Add --working-dir alias for output directory

* Update test case to utilize --working-dir alist for output dir

* Populate GCP_METADATA by membership monitoring config

* Add local variables for lint

* Address line-variable error

* Revert "Populate GCP_METADATA by membership monitoring config"

This reverts commit b3372bd6c4dbaed869ad4006a9a41a5352bda9ec.

* Do not support channel selection via CLI args (#1488)

Allowing this gives the wrong impression that GKE and ASM channels are independent, which is useless at best and dangerous at worst. We shouldn't be making it easier for customers to run nonstandard environments.

* Update verbose help text for consistency with public docs (#1487)

* Support the regionalized membership name parsing (#1490)

* Revert "Do not support channel selection via CLI args (#1488)"

This reverts commit 8c09b8fa4f759982da2773351e34ff06754401a3. Will re-commit when the channel labeling issue is solved a bit cleaner.

* Bump revision 1.18.2-asm.4 (#1493)

---------