### PR TITLE
Adjust required dependencies for privateca.googleapis.com

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -3020,9 +3020,6 @@ required_apis() {
 mesh.googleapis.com
 EOF
   case "${CA}" in
-   gcp_cas)
-     echo privateca.googleapis.com
-     ;;
    managed_cas)
      echo workloadcertificate.googleapis.com
      ;;
@@ -3041,9 +3038,6 @@ required_fleet_apis() {
   case "${CA}" in
    mesh_ca)
      echo meshca.googleapis.com
-     ;;
-   gcp_cas)
-     echo privateca.googleapis.com
      ;;
    managed_cas)
      echo workloadcertificate.googleapis.com

--- a/asmcli/lib/installation_dependencies.sh
+++ b/asmcli/lib/installation_dependencies.sh
@@ -63,9 +63,6 @@ required_apis() {
 mesh.googleapis.com
 EOF
   case "${CA}" in
-   gcp_cas)
-     echo privateca.googleapis.com
-     ;;
    managed_cas)
      echo workloadcertificate.googleapis.com
      ;;
@@ -84,9 +81,6 @@ required_fleet_apis() {
   case "${CA}" in
    mesh_ca)
      echo meshca.googleapis.com
-     ;;
-   gcp_cas)
-     echo privateca.googleapis.com
      ;;
    managed_cas)
      echo workloadcertificate.googleapis.com


### PR DESCRIPTION
For ca=gcp_cas, since a base requirement is that the ca-pools need to be setup before installing control plane (and we validate that ca-pool config), no need to have a duplicate check to see if privateca.googleapis.com is enabled