### PR TITLE
Organize kpt files even in offline mode

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -470,8 +470,9 @@ create-mesh_prepare_environment() {
         download_kpt_package
       fi
     fi
-    organize_kpt_files
   fi
+
+  organize_kpt_files
 }
 
 patch_trust_domain_aliases() {
@@ -4197,8 +4198,9 @@ EOF
     if should_download_kpt_package; then
       download_kpt_package
     fi
-    organize_kpt_files
   fi
+
+  organize_kpt_files
 }
 
 init() {

--- a/asmcli/commands/create-mesh.sh
+++ b/asmcli/commands/create-mesh.sh
@@ -247,8 +247,9 @@ create-mesh_prepare_environment() {
         download_kpt_package
       fi
     fi
-    organize_kpt_files
   fi
+
+  organize_kpt_files
 }
 
 patch_trust_domain_aliases() {

--- a/asmcli/lib/util.sh
+++ b/asmcli/lib/util.sh
@@ -303,8 +303,9 @@ EOF
     if should_download_kpt_package; then
       download_kpt_package
     fi
-    organize_kpt_files
   fi
+
+  organize_kpt_files
 }
 
 init() {


### PR DESCRIPTION
This fixes some validation that depends on external yaml configuration that would otherwise get skipped and cause incorrect error messages.