### PR TITLE
Update Online Boutique sample to v0.9.0

### DIFF
--- a/samples/online-boutique/kubernetes-manifests/deployments/adservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/adservice.yaml
@@ -33,34 +33,40 @@ spec:
     spec:
       serviceAccountName: ad
       terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
-        - name: server
-          image: gcr.io/google-samples/microservices-demo/adservice:v0.3.6
-          ports:
-            - containerPort: 9555
-          env:
-            - name: PORT
-              value: "9555"
-            - name: DISABLE_STATS
-              value: "1"
-            - name: DISABLE_TRACING
-              value: "1"
-          # - name: JAEGER_SERVICE_ADDR
-          #   value: "jaeger-collector:14268"
-          resources:
-            requests:
-              cpu: 200m
-              memory: 180Mi
-            limits:
-              cpu: 300m
-              memory: 300Mi
-          readinessProbe:
-            initialDelaySeconds: 20
-            periodSeconds: 15
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:9555"]
-          livenessProbe:
-            initialDelaySeconds: 20
-            periodSeconds: 15
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:9555"]
+      - name: server
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.9.0
+        ports:
+        - containerPort: 9555
+        env:
+        - name: PORT
+          value: "9555"
+        resources:
+          requests:
+            cpu: 200m
+            memory: 180Mi
+          limits:
+            cpu: 300m
+            memory: 300Mi
+        readinessProbe:
+          initialDelaySeconds: 20
+          periodSeconds: 15
+          grpc:
+            port: 9555
+        livenessProbe:
+          initialDelaySeconds: 20
+          periodSeconds: 15
+          grpc:
+            port: 9555

--- a/samples/online-boutique/kubernetes-manifests/deployments/cartservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/cartservice.yaml
@@ -34,9 +34,21 @@ spec:
     spec:
       serviceAccountName: cart
       terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.6
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.9.0
         ports:
         - containerPort: 7070
         env:
@@ -51,10 +63,10 @@ spec:
             memory: 128Mi
         readinessProbe:
           initialDelaySeconds: 15
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
+          grpc:
+            port: 7070
         livenessProbe:
           initialDelaySeconds: 15
           periodSeconds: 10
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
+          grpc:
+            port: 7070

--- a/samples/online-boutique/kubernetes-manifests/deployments/checkoutservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/checkoutservice.yaml
@@ -35,15 +35,22 @@ spec:
       serviceAccountName: checkout
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.6
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.9.0
           ports:
           - containerPort: 5050
           readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:5050"]
+            grpc:
+              port: 5050
           livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:5050"]
+            grpc:
+              port: 5050
           env:
           - name: PORT
             value: "5050"
@@ -59,14 +66,6 @@ spec:
             value: "currencyservice.currency.svc.cluster.local:7000"
           - name: CART_SERVICE_ADDR
             value: "cartservice.cart.svc.cluster.local:7070"
-          - name: DISABLE_STATS
-            value: "1"
-          - name: DISABLE_TRACING
-            value: "1"
-          - name: DISABLE_PROFILER
-            value: "1"
-          # - name: JAEGER_SERVICE_ADDR
-          #   value: "jaeger-collector:14268"
           resources:
             requests:
               cpu: 100m

--- a/samples/online-boutique/kubernetes-manifests/deployments/currencyservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/currencyservice.yaml
@@ -34,27 +34,35 @@ spec:
     spec:
       serviceAccountName: currency
       terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.6
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.9.0
         ports:
         - name: grpc
           containerPort: 7000
         env:
         - name: PORT
           value: "7000"
-        - name: DISABLE_TRACING
-          value: "1"
         - name: DISABLE_PROFILER
           value: "1"
-        - name: DISABLE_DEBUGGER
-          value: "1"
         readinessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7000"]
+          grpc:
+            port: 7000
         livenessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7000"]
+          grpc:
+            port: 7000
         resources:
           requests:
             cpu: 100m

--- a/samples/online-boutique/kubernetes-manifests/deployments/emailservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/emailservice.yaml
@@ -48,7 +48,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.6
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.9.0
         ports:
         - containerPort: 8080
         env:

--- a/samples/online-boutique/kubernetes-manifests/deployments/emailservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/emailservice.yaml
@@ -33,26 +33,37 @@ spec:
         app: emailservice
     spec:
       serviceAccountName: email
+      terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: server
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
         image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.6
         ports:
         - containerPort: 8080
         env:
         - name: PORT
           value: "8080"
-        - name: DISABLE_TRACING
-          value: "1"
         - name: DISABLE_PROFILER
           value: "1"
         readinessProbe:
           periodSeconds: 5
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:8080"]
+          grpc:
+            port: 8080
         livenessProbe:
           periodSeconds: 5
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:8080"]
+          grpc:
+            port: 8080
         resources:
           requests:
             cpu: 100m

--- a/samples/online-boutique/kubernetes-manifests/deployments/frontend.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/frontend.yaml
@@ -35,9 +35,21 @@ spec:
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       serviceAccountName: frontend
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.3.6
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.9.0
           ports:
           - containerPort: 8080
           readinessProbe:
@@ -73,16 +85,19 @@ spec:
             value: "checkoutservice.checkout.svc.cluster.local:5050"
           - name: AD_SERVICE_ADDR
             value: "adservice.ad.svc.cluster.local:9555"
-          # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem
-          # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp 
-          # - name: ENV_PLATFORM 
+          # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem, alibaba
+          # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp
+          # - name: ENV_PLATFORM
           #   value: "aws"
-          - name: DISABLE_TRACING
-            value: "1"
-          - name: DISABLE_PROFILER
-            value: "1"
-          # - name: JAEGER_SERVICE_ADDR
-          #   value: "jaeger-collector:14268"
+          - name: ENABLE_PROFILER
+            value: "0"
+          # - name: CYMBAL_BRANDING
+          #   value: "true"
+          # - name: FRONTEND_MESSAGE
+          #   value: "Replace this with a message you want to display on all pages."
+          # As part of an optional Google Cloud demo, you can run an optional microservice called the "packaging service".
+          # - name: PACKAGING_SERVICE_URL
+          #   value: "" # This value would look like "http://123.123.123"
           resources:
             requests:
               cpu: 100m

--- a/samples/online-boutique/kubernetes-manifests/deployments/loadgenerator.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/loadgenerator.yaml
@@ -37,9 +37,44 @@ spec:
       serviceAccountName: loadgenerator
       terminationGracePeriodSeconds: 5
       restartPolicy: Always
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      initContainers:
+      - command:
+        - /bin/sh
+        - -exc
+        - |
+          echo "Init container pinging frontend: ${FRONTEND_ADDR}..."
+          STATUSCODE=$(wget --server-response http://${FRONTEND_ADDR} 2>&1 | awk '/^  HTTP/{print $2}')
+          if test $STATUSCODE -ne 200; then
+              echo "Error: Could not reach frontend - Status code: ${STATUSCODE}"
+              exit 1
+          fi
+        name: frontend-check
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: busybox:latest
+        env:
+        - name: FRONTEND_ADDR
+          value: "frontend.frontend.svc.cluster.local:80"
       containers:
       - name: main
-        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.3.6
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.9.0
         env:
         - name: FRONTEND_ADDR
           value: "frontend.frontend.svc.cluster.local:80"

--- a/samples/online-boutique/kubernetes-manifests/deployments/paymentservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/paymentservice.yaml
@@ -34,26 +34,34 @@ spec:
     spec:
       serviceAccountName: payment
       terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.6
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.9.0
         ports:
         - containerPort: 50051
         env:
         - name: PORT
           value: "50051"
-        - name: DISABLE_TRACING
-          value: "1"
         - name: DISABLE_PROFILER
           value: "1"
-        - name: DISABLE_DEBUGGER
-          value: "1"
         readinessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:50051"]
+          grpc:
+            port: 50051
         livenessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:50051"]
+          grpc:
+            port: 50051
         resources:
           requests:
             cpu: 100m

--- a/samples/online-boutique/kubernetes-manifests/deployments/productcatalogservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/productcatalogservice.yaml
@@ -48,7 +48,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: productcatalogservice
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.9.0
         ports:
         - containerPort: 3550
         env:

--- a/samples/online-boutique/kubernetes-manifests/deployments/productcatalogservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/productcatalogservice.yaml
@@ -34,28 +34,34 @@ spec:
     spec:
       serviceAccountName: product-catalog
       terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.6
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: productcatalogservice
         ports:
         - containerPort: 3550
         env:
         - name: PORT
           value: "3550"
-        - name: DISABLE_STATS
-          value: "1"
-        - name: DISABLE_TRACING
-          value: "1"
         - name: DISABLE_PROFILER
           value: "1"
-        # - name: JAEGER_SERVICE_ADDR
-        #   value: "jaeger-collector:14268"
         readinessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:3550"]
+          grpc:
+            port: 3550
         livenessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:3550"]
+          grpc:
+            port: 3550
         resources:
           requests:
             cpu: 100m

--- a/samples/online-boutique/kubernetes-manifests/deployments/recommendationservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/recommendationservice.yaml
@@ -34,29 +34,37 @@ spec:
     spec:
       serviceAccountName: recommendation
       terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.6
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.9.0
         ports:
         - containerPort: 8080
         readinessProbe:
           periodSeconds: 5
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:8080"]
+          grpc:
+            port: 8080
         livenessProbe:
           periodSeconds: 5
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:8080"]
+          grpc:
+            port: 8080
         env:
         - name: PORT
           value: "8080"
         - name: PRODUCT_CATALOG_SERVICE_ADDR
           value: "productcatalogservice.product-catalog.svc.cluster.local:3550"
-        - name: DISABLE_TRACING
-          value: "1"
         - name: DISABLE_PROFILER
-          value: "1"
-        - name: DISABLE_DEBUGGER
           value: "1"
         resources:
           requests:

--- a/samples/online-boutique/kubernetes-manifests/deployments/shippingservice.yaml
+++ b/samples/online-boutique/kubernetes-manifests/deployments/shippingservice.yaml
@@ -33,29 +33,35 @@ spec:
         app: shippingservice
     spec:
       serviceAccountName: shipping
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.6
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.9.0
         ports:
         - containerPort: 50051
         env:
         - name: PORT
           value: "50051"
-        - name: DISABLE_STATS
-          value: "1"
-        - name: DISABLE_TRACING
-          value: "1"
         - name: DISABLE_PROFILER
           value: "1"
-        # - name: JAEGER_SERVICE_ADDR
-        #   value: "jaeger-collector:14268"
         readinessProbe:
           periodSeconds: 5
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:50051"]
+          grpc:
+            port: 50051
         livenessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:50051"]
+          grpc:
+            port: 50051
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
### Background
* See Google-internal bug: [b/324253531](http://b/324253531).
* This repo uses an old version of Online Boutique (v0.3.6) — we should update it to the latest (v0.9.0).

### What is this pull-request doing?
* We are:
   * updating the Online Boutique microservice images to `v0.9.0`.
   * updating the other parts of `Deployment` resources which changed between `v0.3.6` and `v0.9.0`.

### Testing this pull-request
* Unfortunately, we don't have automated tests for these changes.
* I manually tested the tutorial at [Deploying the Online Boutique sample application](https://cloud.google.com/service-mesh/docs/onlineboutique-install-kpt) using the changes from this pull-request (without the ASM parts):
```bash
# Download changes from this pull-request.
kpt pkg get \
  https://github.com/NimJay/anthos-service-mesh-packages.git/samples/online-boutique@nimjay-online-boutique-v0.9.0 \
  online-boutique
```

![Screenshot 2024-02-07 at 5 54 27 PM](https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/assets/10292865/206cca7e-46a9-4985-ab20-f33afd4fbbcb)


### For future reference
* When we need to make this update in the future, [this comment might help](https://github.com/GoogleCloudPlatform/microservices-demo/issues/2367#issuecomment-1933017509). Make sure to also leave variables such as AD_SERVICE_ADDR intact.