### PR TITLE
[1.20] Fix cloud-sdk:slim

### DIFF
--- a/asmcli/Dockerfile
+++ b/asmcli/Dockerfile
@@ -17,6 +17,6 @@ RUN \
   curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg && \
   mv bazel.gpg /etc/apt/trusted.gpg.d/ && \
   echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
-  apt update -y && apt install bazel -y
+  apt update --allow-releaseinfo-change -y && apt install bazel -y
 
 ENTRYPOINT [ "bash" ]


### PR DESCRIPTION
Adding `--allow-releaseinfo-change` flag as per https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/378