### PR TITLE
Removed EnableCAServer flag from migration option

### DIFF
--- a/asm/istio/options/ca-migration-meshca.yaml
+++ b/asm/istio/options/ca-migration-meshca.yaml
@@ -19,7 +19,6 @@ spec:
   values:
     pilot:
       env:
-        ENABLE_CA_SERVER: false
         ISTIO_MULTIROOT_MESH: true
   meshConfig:
     defaultConfig:


### PR DESCRIPTION
This PR removes the flag that prevents the pods from startup when MeshCA is selected.