### PR TITLE
Revert "Updated the kube-rbac-proxy container image in the canonical-service-controller-manager"

### DIFF
--- a/asm/canonical-service/controller.yaml
+++ b/asm/canonical-service/controller.yaml
@@ -310,7 +310,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: bitnami/kube-rbac-proxy
         name: kube-rbac-proxy
         resources:
           limits:


### PR DESCRIPTION
Reverts GoogleCloudPlatform/anthos-service-mesh-packages#1869