### PR TITLE
update asmcli version

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -76,7 +76,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.tag
-          value: 1.27.4-asm.1
+          value: 1.28.2-asm.4
           isSet: true
     io.k8s.cli.setters.anthos.servicemesh.managed-controlplane.vpcsc.enabled:
       type: string

--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -76,7 +76,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.tag
-          value: 1.28.5-asm.9
+          value: 1.28.5-asm.12
           isSet: true
     io.k8s.cli.setters.anthos.servicemesh.managed-controlplane.vpcsc.enabled:
       type: string

--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -76,7 +76,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.tag
-          value: 1.28.2-asm.4
+          value: 1.28.5-asm.9
           isSet: true
     io.k8s.cli.setters.anthos.servicemesh.managed-controlplane.vpcsc.enabled:
       type: string

--- a/asm/canonical-service/controller.yaml
+++ b/asm/canonical-service/controller.yaml
@@ -310,7 +310,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: bitnami/kube-rbac-proxy
         name: kube-rbac-proxy
         resources:
           limits:

--- a/asmcli/Dockerfile
+++ b/asmcli/Dockerfile
@@ -17,6 +17,6 @@ RUN \
   curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg && \
   mv bazel.gpg /etc/apt/trusted.gpg.d/ && \
   echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
-  apt update --allow-releaseinfo-change -y && apt install bazel -y
+  apt update --allow-releaseinfo-change -y && apt install bazel-8.5.1 -y && ln -sf /usr/bin/bazel-8.5.1 /usr/bin/bazel
 
 ENTRYPOINT [ "bash" ]

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -39,9 +39,9 @@ _CI_I_AM_A_TEST_ROBOT="${_CI_I_AM_A_TEST_ROBOT:=0}"; readonly _CI_I_AM_A_TEST_RO
 
 ### Internal variables ###
 MAJOR="${MAJOR:=1}"; readonly MAJOR;
-MINOR="${MINOR:=27}"; readonly MINOR;
-POINT="${POINT:=4}"; readonly POINT;
-REV="${REV:=1}"; readonly REV;
+MINOR="${MINOR:=28}"; readonly MINOR;
+POINT="${POINT:=2}"; readonly POINT;
+REV="${REV:=4}"; readonly REV;
 CONFIG_VER="${CONFIG_VER:="1"}"; readonly CONFIG_VER;
 K8S_MINOR=0
 

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -40,8 +40,8 @@ _CI_I_AM_A_TEST_ROBOT="${_CI_I_AM_A_TEST_ROBOT:=0}"; readonly _CI_I_AM_A_TEST_RO
 ### Internal variables ###
 MAJOR="${MAJOR:=1}"; readonly MAJOR;
 MINOR="${MINOR:=28}"; readonly MINOR;
-POINT="${POINT:=2}"; readonly POINT;
-REV="${REV:=4}"; readonly REV;
+POINT="${POINT:=5}"; readonly POINT;
+REV="${REV:=9}"; readonly REV;
 CONFIG_VER="${CONFIG_VER:="1"}"; readonly CONFIG_VER;
 K8S_MINOR=0
 

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -41,7 +41,7 @@ _CI_I_AM_A_TEST_ROBOT="${_CI_I_AM_A_TEST_ROBOT:=0}"; readonly _CI_I_AM_A_TEST_RO
 MAJOR="${MAJOR:=1}"; readonly MAJOR;
 MINOR="${MINOR:=28}"; readonly MINOR;
 POINT="${POINT:=5}"; readonly POINT;
-REV="${REV:=9}"; readonly REV;
+REV="${REV:=12}"; readonly REV;
 CONFIG_VER="${CONFIG_VER:="1"}"; readonly CONFIG_VER;
 K8S_MINOR=0
 

--- a/asmcli/asmcli.sh
+++ b/asmcli/asmcli.sh
@@ -35,9 +35,9 @@ _CI_I_AM_A_TEST_ROBOT="${_CI_I_AM_A_TEST_ROBOT:=0}"; readonly _CI_I_AM_A_TEST_RO
 
 ### Internal variables ###
 MAJOR="${MAJOR:=1}"; readonly MAJOR;
-MINOR="${MINOR:=27}"; readonly MINOR;
-POINT="${POINT:=4}"; readonly POINT;
-REV="${REV:=1}"; readonly REV;
+MINOR="${MINOR:=28}"; readonly MINOR;
+POINT="${POINT:=2}"; readonly POINT;
+REV="${REV:=4}"; readonly REV;
 CONFIG_VER="${CONFIG_VER:="1"}"; readonly CONFIG_VER;
 K8S_MINOR=0
 

--- a/asmcli/asmcli.sh
+++ b/asmcli/asmcli.sh
@@ -36,8 +36,8 @@ _CI_I_AM_A_TEST_ROBOT="${_CI_I_AM_A_TEST_ROBOT:=0}"; readonly _CI_I_AM_A_TEST_RO
 ### Internal variables ###
 MAJOR="${MAJOR:=1}"; readonly MAJOR;
 MINOR="${MINOR:=28}"; readonly MINOR;
-POINT="${POINT:=2}"; readonly POINT;
-REV="${REV:=4}"; readonly REV;
+POINT="${POINT:=5}"; readonly POINT;
+REV="${REV:=9}"; readonly REV;
 CONFIG_VER="${CONFIG_VER:="1"}"; readonly CONFIG_VER;
 K8S_MINOR=0
 

--- a/asmcli/asmcli.sh
+++ b/asmcli/asmcli.sh
@@ -37,7 +37,7 @@ _CI_I_AM_A_TEST_ROBOT="${_CI_I_AM_A_TEST_ROBOT:=0}"; readonly _CI_I_AM_A_TEST_RO
 MAJOR="${MAJOR:=1}"; readonly MAJOR;
 MINOR="${MINOR:=28}"; readonly MINOR;
 POINT="${POINT:=5}"; readonly POINT;
-REV="${REV:=9}"; readonly REV;
+REV="${REV:=12}"; readonly REV;
 CONFIG_VER="${CONFIG_VER:="1"}"; readonly CONFIG_VER;
 K8S_MINOR=0
 

--- a/asmcli/cloudbuild-main.yaml
+++ b/asmcli/cloudbuild-main.yaml
@@ -112,6 +112,7 @@ steps:
         ../scripts/release-asm/release_asm_installer
     env:
       - '_DEBUG=1'
+      - '_BUCKET_PATH=${_BUCKET_PATH}'
     timeout: 10s
 
     #############
@@ -156,6 +157,7 @@ steps:
     timeout: 900s
 
 substitutions:
+  _BUCKET_PATH: staging_artifacts
   _BUCKET_NAME: my-gcs-bucket
   _CLUSTER_LOCATION: us-central1-c
   _IMAGE_NAME: gcloud-with-kpt

--- a/scripts/release-asm/common.sh
+++ b/scripts/release-asm/common.sh
@@ -24,9 +24,9 @@ trap 'gsutil retention "${HOLD_TYPE}" release gs://"${STABLE_VERSION_FILE_PATH}"
 
 prod_releases() {
   cat << EOF
-release 1.25
 release 1.26
 release 1.27
+release 1.28
 EOF
 }
 
@@ -34,9 +34,9 @@ CURRENT_RELEASE="$(prod_releases | tail -n 1)"; readonly CURRENT_RELEASE
 
 staging_releases() {
   cat << EOF
-staging 1.25
 staging 1.26
 staging 1.27
+staging 1.28
 EOF
 }
 

--- a/scripts/release-asm/common.sh
+++ b/scripts/release-asm/common.sh
@@ -14,7 +14,9 @@ if [[ "${_DEBUG}" -eq 1 ]]; then
 fi
 
 BUCKET_URL="https://storage.googleapis.com"
-BUCKET_PATH="csm-artifacts/asm"; readonly BUCKET_PATH
+# Check if _BUCKET_PATH is in the environment; if not, use the default
+BUCKET_PATH="${_BUCKET_PATH:-csm-artifacts/asm}"
+readonly BUCKET_PATH
 
 
 STABLE_VERSION_FILE="ASMCLI_VERSIONS"; readonly STABLE_VERSION_FILE

--- a/scripts/release-asm/common.sh
+++ b/scripts/release-asm/common.sh
@@ -1,5 +1,8 @@
 _DEBUG="${_DEBUG:=}"
 if [[ "${_DEBUG}" -eq 1 ]]; then
+  gcloud() {
+    echo "DEBUG: would have run 'gcloud storage ${*}'" >&2
+  }
   gsutil() {
     echo "DEBUG: would have run 'gsutil ${*}'" >&2
   }


### PR DESCRIPTION
- **Bump Rev 1.28.2-asm.4 (#1779)**
- **fix: pin Bazel version to 8.5.1 and symlink binary (#1802) (#1807)**
- **fix: implement global trap and dynamic webhook cleanup (#1819) (#1822)**
- **Staging 1.28 for bumping asmcli to 1.28.5-asm.9. (#1834)**
- **Update controller.yaml**
- **change bucket for CL CI builds (#1844)**
- **add gcloud mocking when in debug mode (#1861)**
- **Bump Rev 1.28.5-asm.12 (#1868)**
