### PR TITLE
bump rev-1.27.9-asm.9

### DIFF
--- a/asm/Kptfile
+++ b/asm/Kptfile
@@ -76,7 +76,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: anthos.servicemesh.tag
-          value: 1.27.9-asm.8
+          value: 1.27.9-asm.9
           isSet: true
     io.k8s.cli.setters.anthos.servicemesh.managed-controlplane.vpcsc.enabled:
       type: string

--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -41,7 +41,7 @@ _CI_I_AM_A_TEST_ROBOT="${_CI_I_AM_A_TEST_ROBOT:=0}"; readonly _CI_I_AM_A_TEST_RO
 MAJOR="${MAJOR:=1}"; readonly MAJOR;
 MINOR="${MINOR:=27}"; readonly MINOR;
 POINT="${POINT:=9}"; readonly POINT;
-REV="${REV:=8}"; readonly REV;
+REV="${REV:=9}"; readonly REV;
 CONFIG_VER="${CONFIG_VER:="1"}"; readonly CONFIG_VER;
 K8S_MINOR=0
 

--- a/asmcli/asmcli.sh
+++ b/asmcli/asmcli.sh
@@ -37,7 +37,7 @@ _CI_I_AM_A_TEST_ROBOT="${_CI_I_AM_A_TEST_ROBOT:=0}"; readonly _CI_I_AM_A_TEST_RO
 MAJOR="${MAJOR:=1}"; readonly MAJOR;
 MINOR="${MINOR:=27}"; readonly MINOR;
 POINT="${POINT:=9}"; readonly POINT;
-REV="${REV:=8}"; readonly REV;
+REV="${REV:=9}"; readonly REV;
 CONFIG_VER="${CONFIG_VER:="1"}"; readonly CONFIG_VER;
 K8S_MINOR=0
 


### PR DESCRIPTION
- **Bump rev 1.27.4-asm.1 (#1776)**
- **Bump Rev 1.28.2-asm.4 (#1779) (#1783)**
- **chore: Migrate gsutil usage to gcloud storage (#1777)**
- **fix: implement global trap and dynamic webhook cleanup (#1819) (#1825)**
- **Update controller.yaml**
- **fixing bazel issue and update GCS public permissions to use legacyObjectReader IAM role (#1838)**
- **change bucket for CL CI builds (#1844) (#1846)**
- **bump rev 1.29.4-asm.0 (#1899) (#1909)**
- **bump rev-1.27.9-asm.9**
