### PR TITLE
fix(ci): enable gcp components in basic suite test

### DIFF
--- a/asmcli/tests/run_basic_suite
+++ b/asmcli/tests/run_basic_suite
@@ -19,7 +19,7 @@ main() {
   export OUTPUT_DIR="$(mktemp -d)"
   run_build_offline_package "${OUTPUT_DIR}"
 
-  run_basic_test "install" "mesh_ca" "--revision_name ${REVISION_LABEL} --offline"; RETVAL=$?;
+  run_basic_test "install" "mesh_ca" "--revision_name ${REVISION_LABEL} --offline --enable_gcp_components"; RETVAL=$?;
 
   echo "Verifying service mesh feature is enabled..."
     if ! is_service_mesh_feature_enabled; then


### PR DESCRIPTION
## Description
This PR fixes the failing CI tests for in-cluster CSM installations on branch 1.27+.

### Problem
A recent change made the service mesh feature mandatory for both Managed and In-cluster CSM installations. However, the `tests/run_basic_suite` script was running `asmcli` without the `--enable_gcp_components` flag, causing it to fail validation when the service mesh feature was not already enabled on the project.

### Solution
Added the `--enable_gcp_components` flag to the `asmcli` invocation in `tests/run_basic_suite` to allow it to automatically enable the required feature during the test run.