### PR TITLE
fix(ci): enable gcp components in basic suite test

### DIFF
--- a/asmcli/tests/common.sh
+++ b/asmcli/tests/common.sh
@@ -822,31 +822,14 @@ run_build_offline_package() {
 
 delete_service_mesh_feature() {
   echo "Removing the service mesh feature from the project ${PROJECT_ID}..."
-
-  local TOKEN
-  TOKEN="$(gcloud --project="${PROJECT_ID}" auth print-access-token)"
-
-  curl -s -H "X-Goog-User-Project: ${PROJECT_ID}"  \
-    -X DELETE \
-    "https://gkehub.googleapis.com/v1alpha1/projects/${PROJECT_ID}/locations/global/features/servicemesh" \
-    -H @- <<EOF
-Authorization: Bearer ${TOKEN}
-EOF
+  gcloud container fleet mesh disable --project="${PROJECT_ID}" --quiet 2>/dev/null || true
 }
 
 is_service_mesh_feature_enabled() {
-  local TOKEN
-  TOKEN="$(gcloud --project="${PROJECT_ID}" auth print-access-token)"
-
   local RESPONSE
-  RESPONSE="$(curl -s -H "X-Goog-User-Project: ${PROJECT_ID}"  \
-    "https://gkehub.googleapis.com/v1alpha1/projects/${PROJECT_ID}/locations/global/features/servicemesh" \
-    -H @- <<EOF
-Authorization: Bearer ${TOKEN}
-EOF
-)"
+  RESPONSE="$(gcloud container fleet mesh describe --project="${PROJECT_ID}" --format=json 2>/dev/null)"
 
-  if [[ "$(echo "${RESPONSE}" | jq -r '.featureState.lifecycleState')" != "ENABLED" ]]; then
+  if [[ "$(echo "${RESPONSE}" | jq -r '.resourceState.state')" != "ACTIVE" ]]; then
     false
   fi
 }

--- a/asmcli/tests/run_basic_suite
+++ b/asmcli/tests/run_basic_suite
@@ -19,7 +19,7 @@ main() {
   export OUTPUT_DIR="$(mktemp -d)"
   run_build_offline_package "${OUTPUT_DIR}"
 
-  run_basic_test "install" "mesh_ca" "--revision_name ${REVISION_LABEL} --offline"; RETVAL=$?;
+  run_basic_test "install" "mesh_ca" "--revision_name ${REVISION_LABEL} --offline --enable_gcp_components"; RETVAL=$?;
 
   echo "Verifying service mesh feature is enabled..."
     if ! is_service_mesh_feature_enabled; then


### PR DESCRIPTION
## Description
This PR fixes the failing CI tests for in-cluster CSM installations on branch 1.27+.

### Problem
A recent change made the service mesh feature mandatory for both Managed and In-cluster CSM installations. However, the `tests/run_basic_suite` script was running `asmcli` without the `--enable_gcp_components` flag, causing it to fail validation when the service mesh feature was not already enabled on the project.

### Solution
Added the `--enable_gcp_components` flag to the `asmcli` invocation in `tests/run_basic_suite` to allow it to automatically enable the required feature during the test run.