### PR TITLE
asmcli: fix STS audience, GCS auth token, and overlay parsing loops

### DIFF
--- a/asmcli/asmcli
+++ b/asmcli/asmcli
@@ -3342,6 +3342,7 @@ populate_fleet_info() {
   HUB_MEMBERSHIP_ID="$(kubectl get memberships.hub.gke.io membership -o=json | jq .spec.owner.id | sed 's/^\"\/\/\(autopush-\)\{0,1\}gkehub\(.sandbox\)\{0,1\}.googleapis.com\/projects\/\(.*\)\/locations\/\(.*\)\/memberships\/\(.*\)\"$/\5/g')"
   context_set-option "HUB_MEMBERSHIP_ID" "${HUB_MEMBERSHIP_ID}"
   HUB_IDP_URL="$(kubectl get memberships.hub.gke.io membership -o=jsonpath='{.spec.identity_provider}')"
+  HUB_IDP_URL="${HUB_IDP_URL//container.mtls.googleapis.com/container.googleapis.com}"
   context_set-option "HUB_IDP_URL" "${HUB_IDP_URL}"
 }
 
@@ -3371,7 +3372,7 @@ register_gce_identity_provider() {
 
 get_auth_token() {
   local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
-  local TOKEN; TOKEN="$(retry 2 gcloud --project="${PROJECT_ID}" auth print-access-token)"
+  local TOKEN; TOKEN="$(gcloud auth application-default print-access-token 2>/dev/null || retry 2 gcloud --project="${PROJECT_ID}" auth print-access-token)"
   echo "${TOKEN}"
 }
 info() {
@@ -4048,7 +4049,7 @@ download_asm() {
         | tar xz
     fi
   else
-    local TOKEN; TOKEN="$(retry 2 gcloud --project="${PROJECT_ID}" auth print-access-token)"
+    local TOKEN; TOKEN="$(gcloud auth application-default print-access-token 2>/dev/null || retry 2 gcloud --project="${PROJECT_ID}" auth print-access-token)"
     run_command curl -sSL "https://storage.googleapis.com/${_CI_ASM_PKG_LOCATION}/asm/${TARBALL}" \
       --header @- <<EOF | tar xz
 Authorization: Bearer ${TOKEN}
@@ -4407,6 +4408,7 @@ organize_kpt_files() {
   local OPTIONAL_OVERLAY; OPTIONAL_OVERLAY="$(context_get-option "OPTIONAL_OVERLAY")"
 
   while read -d ',' -r yaml_file; do
+    [[ -z "${yaml_file}" ]] && continue
     ABS_YAML="${OPTIONS_DIRECTORY}/${yaml_file}.yaml"
     if [[ ! -f "${ABS_YAML}" ]]; then
     { read -r -d '' MSG; fatal "${MSG}"; } <<EOF || true
@@ -4431,6 +4433,7 @@ handle_multi_yaml_bug() {
   local CSPLIT_OUTPUT; CSPLIT_OUTPUT="";
   local BASE_NAME
   while read -d ',' -r yaml_file; do
+    [[ -z "${yaml_file}" ]] && continue
     BASE_NAME="$(basename "${yaml_file}")"
     if [[ "$(csplit -f "overlay-${BASE_NAME}" "${yaml_file}" '/^---$/' '{*}' | wc -l)" -eq 1 ]]; then
       CSPLIT_OUTPUT="${CSPLIT_OUTPUT},${yaml_file}"
@@ -4454,6 +4457,7 @@ post_process_istio_yamls() {
   handle_multi_yaml_bug
 
   while read -d ',' -r yaml_file; do
+    [[ -z "${yaml_file}" ]] && continue
     context_append "istioctlFiles" "${yaml_file}"
   done <<EOF
 $(context_get-option "CUSTOM_OVERLAY")
@@ -5495,6 +5499,7 @@ EOF
 
   local ABS_OVERLAYS; ABS_OVERLAYS=""
   while read -d ',' -r yaml_file; do
+    [[ -z "${yaml_file}" ]] && continue
     if [[ -f "${yaml_file}" ]]; then
       ABS_OVERLAYS="$(apath -f "${yaml_file}"),${ABS_OVERLAYS}"
     elif [[ -n "${yaml_file}" ]]; then

--- a/asmcli/lib/installation_dependencies.sh
+++ b/asmcli/lib/installation_dependencies.sh
@@ -418,6 +418,7 @@ populate_fleet_info() {
   HUB_MEMBERSHIP_ID="$(kubectl get memberships.hub.gke.io membership -o=json | jq .spec.owner.id | sed 's/^\"\/\/\(autopush-\)\{0,1\}gkehub\(.sandbox\)\{0,1\}.googleapis.com\/projects\/\(.*\)\/locations\/\(.*\)\/memberships\/\(.*\)\"$/\5/g')"
   context_set-option "HUB_MEMBERSHIP_ID" "${HUB_MEMBERSHIP_ID}"
   HUB_IDP_URL="$(kubectl get memberships.hub.gke.io membership -o=jsonpath='{.spec.identity_provider}')"
+  HUB_IDP_URL="${HUB_IDP_URL//container.mtls.googleapis.com/container.googleapis.com}"
   context_set-option "HUB_IDP_URL" "${HUB_IDP_URL}"
 }
 
@@ -447,6 +448,6 @@ register_gce_identity_provider() {
 
 get_auth_token() {
   local PROJECT_ID; PROJECT_ID="$(context_get-option "PROJECT_ID")"
-  local TOKEN; TOKEN="$(retry 2 gcloud --project="${PROJECT_ID}" auth print-access-token)"
+  local TOKEN; TOKEN="$(gcloud auth application-default print-access-token 2>/dev/null || retry 2 gcloud --project="${PROJECT_ID}" auth print-access-token)"
   echo "${TOKEN}"
 }

--- a/asmcli/lib/util.sh
+++ b/asmcli/lib/util.sh
@@ -192,7 +192,7 @@ download_asm() {
         | tar xz
     fi
   else
-    local TOKEN; TOKEN="$(retry 2 gcloud --project="${PROJECT_ID}" auth print-access-token)"
+    local TOKEN; TOKEN="$(gcloud auth application-default print-access-token 2>/dev/null || retry 2 gcloud --project="${PROJECT_ID}" auth print-access-token)"
     run_command curl -sSL "https://storage.googleapis.com/${_CI_ASM_PKG_LOCATION}/asm/${TARBALL}" \
       --header @- <<EOF | tar xz
 Authorization: Bearer ${TOKEN}
@@ -551,6 +551,7 @@ organize_kpt_files() {
   local OPTIONAL_OVERLAY; OPTIONAL_OVERLAY="$(context_get-option "OPTIONAL_OVERLAY")"
 
   while read -d ',' -r yaml_file; do
+    [[ -z "${yaml_file}" ]] && continue
     ABS_YAML="${OPTIONS_DIRECTORY}/${yaml_file}.yaml"
     if [[ ! -f "${ABS_YAML}" ]]; then
     { read -r -d '' MSG; fatal "${MSG}"; } <<EOF || true
@@ -575,6 +576,7 @@ handle_multi_yaml_bug() {
   local CSPLIT_OUTPUT; CSPLIT_OUTPUT="";
   local BASE_NAME
   while read -d ',' -r yaml_file; do
+    [[ -z "${yaml_file}" ]] && continue
     BASE_NAME="$(basename "${yaml_file}")"
     if [[ "$(csplit -f "overlay-${BASE_NAME}" "${yaml_file}" '/^---$/' '{*}' | wc -l)" -eq 1 ]]; then
       CSPLIT_OUTPUT="${CSPLIT_OUTPUT},${yaml_file}"
@@ -598,6 +600,7 @@ post_process_istio_yamls() {
   handle_multi_yaml_bug
 
   while read -d ',' -r yaml_file; do
+    [[ -z "${yaml_file}" ]] && continue
     context_append "istioctlFiles" "${yaml_file}"
   done <<EOF
 $(context_get-option "CUSTOM_OVERLAY")

--- a/asmcli/lib/validate.sh
+++ b/asmcli/lib/validate.sh
@@ -742,6 +742,7 @@ EOF
 
   local ABS_OVERLAYS; ABS_OVERLAYS=""
   while read -d ',' -r yaml_file; do
+    [[ -z "${yaml_file}" ]] && continue
     if [[ -f "${yaml_file}" ]]; then
       ABS_OVERLAYS="$(apath -f "${yaml_file}"),${ABS_OVERLAYS}"
     elif [[ -n "${yaml_file}" ]]; then


### PR DESCRIPTION
- Sanitize HUB_IDP_URL in populate_fleet_info() to replace container.mtls.googleapis.com with container.googleapis.com to prevent Envoy STS 400 invalid_target errors.
- Update get_auth_token() and GCS download routines to fall back to Application Default Credentials (ADC) token when user CLI tokens lack storage scopes.
- Guard while read -d ',' loops against empty string entries in handle_multi_yaml_bug(), organize_kpt_files(), post_process_istio_yamls(), and validate.sh to fix csplit failures.