### PR TITLE
Applied fixes for pre-checks for staging-1.28

### DIFF
--- a/asmcli/Dockerfile
+++ b/asmcli/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get install google-cloud-cli-kpt jq kubectl google-cloud-cli-gke-gcloud-
 # install test dependencies
 RUN apt-get install shellcheck posh bc procps openssl yamllint -y
 
-# https://docs.bazel.build/versions/master/install-ubuntu.html
+# https://bazel.build/install/ubuntu
 RUN \
   apt install apt-transport-https curl gnupg -y && \
-  curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg && \
+  curl -fsSL https://releases.bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg && \
   mv bazel.gpg /etc/apt/trusted.gpg.d/ && \
   echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
   apt update --allow-releaseinfo-change -y && apt install bazel-8.5.1 -y && ln -sf /usr/bin/bazel-8.5.1 /usr/bin/bazel

--- a/asmcli/tests/common.sh
+++ b/asmcli/tests/common.sh
@@ -232,8 +232,8 @@ verify_demo_app() {
   local PAGE
   local COUNT
 
-  for _ in $(seq 1 30); do
-    PAGE="$(curl "${IP}" -L -N -s || echo "")"
+  for _ in $(seq 1 100); do
+    PAGE="$(curl --max-time 10 "${IP}" -L -N -s || echo "")"
     COUNT="$(echo "${PAGE}" | grep -c Hipster || true)"
     { [[ "${COUNT}" -ne 0 ]] && break; } || sleep 10
   done
@@ -251,7 +251,7 @@ send_persistent_traffic() {
   local PAGE
   local COUNT
   while true; do
-    PAGE="$(curl "${IP}" -L -N -s || echo "")"
+    PAGE="$(curl --max-time 10 "${IP}" -L -N -s || echo "")"
     COUNT="$(echo "${PAGE}" | grep -c Hipster || true)"
     { [[ "${COUNT}" -eq 0 ]] && echo -e "Receive unexpected response from demo app:\n${PAGE}" && exit 1; } || sleep 1
   done

--- a/asmcli/tests/run_basic_suite
+++ b/asmcli/tests/run_basic_suite
@@ -27,7 +27,6 @@ main() {
     fi
 
   cleanup_lt_cluster "${LT_NAMESPACE}" "${OUTPUT_DIR}" "${REV}"
-  delete_service_mesh_feature
   exit "${RETVAL}"
 }
 

--- a/asmcli/tests/run_basic_suite_managed
+++ b/asmcli/tests/run_basic_suite_managed
@@ -23,7 +23,6 @@ main() {
   fi
 
   cleanup_lt_cluster "${LT_NAMESPACE}" "${OUTPUT_DIR}" "${REV}"
-  delete_service_mesh_feature
   exit "${RETVAL}"
 }
 


### PR DESCRIPTION
This PR fixes to pre-check failures in the repo:

Changes made:

Modified the verification step to be more resilient with retries and timeout:
Earlier curl command would just hang while waiting for response since no timeout was configured. Increased the robustness with timeout and increased retries.

Removed deletion of service mesh feature for project:
The service mesh feature is enabled on project level instead of cluster level. Turning it off may cause race condition if multiple tests are running on the project parallely. It is safe to remove the deletion since project is specifically used for asmcli script validation which required service mesh feature to be enabled.

Fixed the dockerfile for build setup phase: Updated bazel release command in favour of new location https://github.com/bazelbuild/bazel/issues/30604